### PR TITLE
Add video-to-audio converter with modern SwiftUI UI

### DIFF
--- a/Resonans/ContentView.swift
+++ b/Resonans/ContentView.swift
@@ -1,21 +1,105 @@
-//
-//  ContentView.swift
-//  Resonans
-//
-//  Created by Lian on 07.09.25.
-//
-
 import SwiftUI
+import AVFoundation
 
 struct ContentView: View {
+    @State private var videoURL: URL?
+    @State private var showPhotoPicker = false
+    @State private var showFilePicker = false
+    @State private var selectedFormat: AudioFormat = .m4a
+    @State private var isConverting = false
+    @State private var message: String?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        ZStack {
+            LinearGradient(colors: [.blue.opacity(0.4), .purple.opacity(0.4)], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            VStack(spacing: 30) {
+                RoundedRectangle(cornerRadius: 25, style: .continuous)
+                    .fill(Color.white)
+                    .shadow(radius: 10)
+                    .frame(height: 260)
+                    .overlay(
+                        VStack(spacing: 20) {
+                            if let url = videoURL {
+                                Text(url.lastPathComponent)
+                                    .font(.headline)
+                                    .foregroundColor(.primary)
+                                    .transition(.opacity)
+                            } else {
+                                Text("Keine Datei gewählt")
+                                    .foregroundColor(.secondary)
+                            }
+                            HStack(spacing: 20) {
+                                Button(action: { showPhotoPicker = true }) {
+                                    Label("Galerie", systemImage: "photo")
+                                }
+                                Button(action: { showFilePicker = true }) {
+                                    Label("Dateien", systemImage: "folder")
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                        .padding()
+                        .animation(.easeInOut, value: videoURL)
+                    )
+
+                Picker("Format", selection: $selectedFormat) {
+                    ForEach(AudioFormat.allCases, id: \.#self) { format in
+                        Text(format.rawValue).tag(format)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                Button(action: convert) {
+                    if isConverting {
+                        ProgressView()
+                    } else {
+                        Text("Konvertieren")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(videoURL == nil || isConverting)
+                .padding(.horizontal)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .shadow(radius: 5)
+
+                if let msg = message {
+                    Text(msg)
+                        .foregroundColor(.green)
+                        .transition(.opacity)
+                }
+            }
+            .padding()
         }
-        .padding()
+        .sheet(isPresented: $showPhotoPicker) {
+            VideoPicker { url in
+                videoURL = url
+            }
+        }
+        .sheet(isPresented: $showFilePicker) {
+            FilePicker { url in
+                videoURL = url
+            }
+        }
+    }
+
+    private func convert() {
+        guard let videoURL else { return }
+        isConverting = true
+        message = nil
+        VideoToAudioConverter.convert(videoURL: videoURL, format: selectedFormat) { result in
+            DispatchQueue.main.async {
+                isConverting = false
+                switch result {
+                case .success(let url):
+                    message = "Gespeichert: \(url.lastPathComponent)"
+                case .failure(let error):
+                    message = "Fehler: \(error.localizedDescription)"
+                }
+            }
+        }
     }
 }
 

--- a/Resonans/FilePicker.swift
+++ b/Resonans/FilePicker.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FilePicker: UIViewControllerRepresentable {
+    var onComplete: (URL) -> Void
+    func makeCoordinator() -> Coordinator { Coordinator(onComplete: onComplete) }
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let types: [UTType] = [.movie]
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: types, asCopy: true)
+        picker.delegate = context.coordinator
+        return picker
+    }
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        var onComplete: (URL) -> Void
+        init(onComplete: @escaping (URL) -> Void) { self.onComplete = onComplete }
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onComplete(url)
+        }
+    }
+}

--- a/Resonans/VideoPicker.swift
+++ b/Resonans/VideoPicker.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import PhotosUI
+import UniformTypeIdentifiers
+
+struct VideoPicker: UIViewControllerRepresentable {
+    var onComplete: (URL) -> Void
+    func makeCoordinator() -> Coordinator { Coordinator(onComplete: onComplete) }
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .videos
+        config.selectionLimit = 1
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        var onComplete: (URL) -> Void
+        init(onComplete: @escaping (URL) -> Void) { self.onComplete = onComplete }
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+            guard let item = results.first else { return }
+            if item.itemProvider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+                item.itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, _ in
+                    if let url = url {
+                        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
+                        try? FileManager.default.removeItem(at: tempURL)
+                        try? FileManager.default.copyItem(at: url, to: tempURL)
+                        DispatchQueue.main.async { self.onComplete(tempURL) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Resonans/VideoToAudioConverter.swift
+++ b/Resonans/VideoToAudioConverter.swift
@@ -1,0 +1,86 @@
+import AVFoundation
+import Foundation
+import LAME
+
+enum AudioFormat: String, CaseIterable {
+    case wav = "WAV"
+    case m4a = "M4A"
+    case mp3 = "MP3"
+}
+
+final class VideoToAudioConverter {
+    static func convert(videoURL: URL, format: AudioFormat, completion: @escaping (Result<URL, Error>) -> Void) {
+        let asset = AVAsset(url: videoURL)
+        let baseName = videoURL.deletingPathExtension().lastPathComponent + "_out"
+        let tmp = FileManager.default.temporaryDirectory
+        switch format {
+        case .wav:
+            let out = tmp.appendingPathComponent(baseName).appendingPathExtension("wav")
+            export(asset: asset, outputURL: out, fileType: .wav, completion: completion)
+        case .m4a:
+            let out = tmp.appendingPathComponent(baseName).appendingPathExtension("m4a")
+            export(asset: asset, outputURL: out, fileType: .m4a, completion: completion)
+        case .mp3:
+            let wavURL = tmp.appendingPathComponent(baseName).appendingPathExtension("wav")
+            export(asset: asset, outputURL: wavURL, fileType: .wav) { result in
+                switch result {
+                case .failure(let err):
+                    completion(.failure(err))
+                case .success:
+                    do {
+                        let mp3URL = tmp.appendingPathComponent(baseName).appendingPathExtension("mp3")
+                        try wavToMp3(wavURL: wavURL, mp3URL: mp3URL)
+                        completion(.success(mp3URL))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                }
+            }
+        }
+    }
+
+    private static func export(asset: AVAsset, outputURL: URL, fileType: AVFileType, completion: @escaping (Result<URL, Error>) -> Void) {
+        guard let exporter = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+            completion(.failure(NSError(domain: "export", code: -1)))
+            return
+        }
+        exporter.outputURL = outputURL
+        exporter.outputFileType = fileType
+        exporter.exportAsynchronously {
+            if exporter.status == .completed {
+                completion(.success(outputURL))
+            } else {
+                completion(.failure(exporter.error ?? NSError(domain: "export", code: -2)))
+            }
+        }
+    }
+
+    private static func wavToMp3(wavURL: URL, mp3URL: URL) throws {
+        guard let pcm = fopen(wavURL.path, "rb") else { throw NSError(domain: "lame", code: -1) }
+        defer { fclose(pcm) }
+        guard let mp3 = fopen(mp3URL.path, "wb") else { throw NSError(domain: "lame", code: -2) }
+        defer { fclose(mp3) }
+        let lame = lame_init()
+        lame_set_in_samplerate(lame, 44100)
+        lame_set_VBR(lame, vbr_default)
+        lame_init_params(lame)
+        let pcmBufferSize: Int32 = 8192
+        var pcmBuffer = [Int16](repeating: 0, count: Int(pcmBufferSize))
+        var mp3Buffer = [UInt8](repeating: 0, count: Int(8192))
+        var read: Int32
+        repeat {
+            read = pcmBuffer.withUnsafeMutableBufferPointer { ptr in
+                fread(ptr.baseAddress, MemoryLayout<Int16>.size, Int(pcmBufferSize), pcm)
+            }
+            let write = lame_encode_buffer_interleaved(lame, &pcmBuffer, read / 2, &mp3Buffer, 8192)
+            mp3Buffer.withUnsafeBufferPointer { ptr in
+                fwrite(ptr.baseAddress, Int(write), 1, mp3)
+            }
+        } while read != 0
+        let flush = lame_encode_flush(lame, &mp3Buffer, 8192)
+        mp3Buffer.withUnsafeBufferPointer { ptr in
+            fwrite(ptr.baseAddress, Int(flush), 1, mp3)
+        }
+        lame_close(lame)
+    }
+}


### PR DESCRIPTION
## Summary
- Provide a polished SwiftUI interface for selecting a video from the gallery or Files, choosing an output format, and starting conversion.
- Add pickers for Photos and Files and a converter that outputs WAV, M4A, or MP3 using AVFoundation and the LAME library.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme Resonans -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc1e3cd94832093eb58be6b5409c0