### PR TITLE
Enable sticky date headers in gallery

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -13,7 +13,8 @@ struct BottomSheetGallery: View {
             asset.creationDate.map { Calendar.current.startOfDay(for: $0) } ?? Date.distantPast
         }
         let sortedDates = grouped.keys.sorted(by: >)
-        LazyVStack(alignment: .leading, spacing: 18) {
+        // Enable sticky date headers while scrolling through the gallery
+        LazyVStack(alignment: .leading, spacing: 18, pinnedViews: [.sectionHeaders]) {
             ForEach(sortedDates, id: \.self) { date in
                 if let items = grouped[date] {
                     Section(header:


### PR DESCRIPTION
## Summary
- Enable sticky date headers in BottomSheetGallery by using pinned section headers

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e491cb3c8320ad3413603aa46033