### PR TITLE
Fix gallery duration display and selection handling

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -28,7 +28,6 @@ struct ContentView: View {
     @State private var selectedTab: Int = 0
     @State private var addCardPage: Int = 0
     @State private var selectedAsset: PHAsset?
-    @State private var isRefreshing = false
 
     var body: some View {
         ZStack {
@@ -53,28 +52,19 @@ struct ContentView: View {
                         .tag(0)
                         ScrollView {
                             LazyVStack {
-                                if isRefreshing {
-                                    ProgressView()
-                                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                        .padding(.top, 20)
-                                }
                                 BottomSheetGallery(
                                     assets: Array(assets.prefix(displayedItemCount)),
                                     onLastItemAppear: loadMoreItems,
                                     selectedAsset: $selectedAsset
                                 )
                                 .padding(.horizontal, 14)
-                                .padding(.top, isRefreshing ? 40 : 20)
-                                .animation(.easeInOut(duration: 0.25), value: isRefreshing)
+                                .padding(.top, 20)
                                 Spacer()
                             }
                         }
                         .refreshable {
                             selectedAsset = nil
-                            isRefreshing = true
-                            loadGallery {
-                                isRefreshing = false
-                            }
+                            loadGallery()
                         }
                         .onAppear {
                             if assets.isEmpty {
@@ -201,6 +191,10 @@ struct ContentView: View {
             if showSourceOptions {
                 withAnimation(.easeInOut(duration: 0.35)) {
                     showSourceOptions = false
+                }
+            } else if selectedAsset != nil {
+                withAnimation {
+                    selectedAsset = nil
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure all gallery videos show their duration
- deselect selected items when tapping empty space
- rely on built-in refresh control to avoid glitchy progress view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebdafa3083209e88c8d76ac599e3