### PR TITLE
Add gradient background to header

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -242,6 +242,16 @@ struct ContentView: View {
             .buttonStyle(.plain)
             .padding(.trailing, 8)
         }
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+        .background(
+            LinearGradient(
+                colors: [Color.black.opacity(0.8), Color.black.opacity(0)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea(edges: .top)
+        )
     }
 
     private var addCard: some View {


### PR DESCRIPTION
## Summary
- Fade header background from black to transparent

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ef51433083209ac3f6f98cf5cff9