### PR TITLE
Refine recents UI and add conversion sheet placeholder

### DIFF
--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -9,7 +9,7 @@ struct RecentRow: View {
                 .fill(Color.white.opacity(0.14))
                 .frame(width: 56, height: 56)
                 .overlay(
-                    Image(systemName: "play.rectangle.fill")
+                    Image(systemName: "waveform")
                         .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.9))
                 )
@@ -19,6 +19,8 @@ struct RecentRow: View {
                 Text(item.title)
                     .font(.system(size: 18, weight: .semibold, design: .rounded))
                     .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 Text(item.duration)
                     .font(.system(size: 14, weight: .regular))
                     .foregroundStyle(.white.opacity(0.8))


### PR DESCRIPTION
## Summary
- Show "None yet" when gallery or recents list is empty
- Add expandable recents list with show more/less
- Open placeholder conversion sheet when starting extraction and use waveform icon with truncated filenames

## Testing
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68c5f4e018108320bee9e1b29ec4dd43