### PR TITLE
Add customizable settings view

### DIFF
--- a/Resonans/Models/Settings.swift
+++ b/Resonans/Models/Settings.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+enum Appearance: String, CaseIterable, Identifiable {
+    case light
+    case dark
+    case system
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .light: return "Light"
+        case .dark: return "Dark"
+        case .system: return "System"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        case .system: return nil
+        }
+    }
+}
+
+enum AccentColorOption: String, CaseIterable, Identifiable {
+    case blue
+    case green
+    case orange
+    case pink
+    case purple
+    case red
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .blue: return .blue
+        case .green: return .green
+        case .orange: return .orange
+        case .pink: return .pink
+        case .purple: return .purple
+        case .red: return .red
+        }
+    }
+
+    var gradient: Color {
+        color.opacity(0.25)
+    }
+}
+

--- a/Resonans/ResonansApp.swift
+++ b/Resonans/ResonansApp.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 @main
 struct ResonansApp: App {
+    @AppStorage("appearance") private var appearanceRaw = Appearance.system.rawValue
+    private var appearance: Appearance { Appearance(rawValue: appearanceRaw) ?? .system }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(appearance.colorScheme)
         }
     }
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -30,11 +30,14 @@ struct ContentView: View {
     @State private var addCardPage: Int = 0
     @State private var selectedAsset: PHAsset?
 
+    @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+
     var body: some View {
         ZStack {
             Color.black.ignoresSafeArea()
                 .overlay(
-                    LinearGradient(colors: [Color.white.opacity(0.06), .clear], startPoint: .topLeading, endPoint: .bottom)
+                    LinearGradient(colors: [accent.gradient, .clear], startPoint: .topLeading, endPoint: .bottom)
                         .ignoresSafeArea()
                 )
             VStack(spacing: 0) {
@@ -80,17 +83,8 @@ struct ContentView: View {
                             }
                         }
                         .tag(1)
-                        ScrollView {
-                            VStack {
-                                Spacer(minLength: 60)
-                                Text("Settings")
-                                    .font(.system(size: 28, weight: .bold, design: .rounded))
-                                    .foregroundStyle(.white.opacity(0.8))
-                                    .padding()
-                                Spacer()
-                            }
-                        }
-                        .tag(2)
+                        SettingsView()
+                            .tag(2)
                     }
                     .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
                     .animation(.easeInOut(duration: 0.3), value: selectedTab)
@@ -138,7 +132,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "house.fill")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(.white.opacity(selectedTab == 0 ? 0.9 : 0.5))
+                                        .foregroundStyle(selectedTab == 0 ? accent.color : Color.white.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -147,7 +141,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "photo.on.rectangle.angled")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(.white.opacity(selectedTab == 1 ? 0.9 : 0.5))
+                                        .foregroundStyle(selectedTab == 1 ? accent.color : Color.white.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -156,7 +150,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "gearshape.fill")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(.white.opacity(selectedTab == 2 ? 0.9 : 0.5))
+                                        .foregroundStyle(selectedTab == 2 ? accent.color : Color.white.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -195,6 +189,7 @@ struct ContentView: View {
                 }
             }
         }
+        .tint(accent.color)
         .contentShape(Rectangle())
         .onTapGesture {
             if showSourceOptions {
@@ -247,9 +242,18 @@ struct ContentView: View {
 
     // MARK: - Subviews
 
+    private var headerTitle: String {
+        switch selectedTab {
+        case 0: return "Resonans"
+        case 1: return "Library"
+        case 2: return "Settings"
+        default: return ""
+        }
+    }
+
     private var header: some View {
         HStack(alignment: .center) {
-            Text("Resonans")
+            Text(headerTitle)
                 .font(.system(size: 46, weight: .heavy, design: .rounded))
                 .tracking(0.5)
                 .foregroundStyle(.white)

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("appearance") private var appearanceRaw = Appearance.system.rawValue
+    @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
+
+    @AppStorage("hapticsEnabled") private var hapticsEnabled = true
+    @AppStorage("soundsEnabled") private var soundsEnabled = true
+    @AppStorage("confirmationsEnabled") private var confirmationsEnabled = true
+
+    private var appearance: Appearance {
+        Appearance(rawValue: appearanceRaw) ?? .system
+    }
+
+    private var accent: AccentColorOption {
+        AccentColorOption(rawValue: accentRaw) ?? .purple
+    }
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                appearanceSection
+                interactionsSection
+                aboutSection
+            }
+            .padding(.vertical, 30)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var appearanceSection: some View {
+        settingsBox {
+            Text("Appearance")
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            HStack(spacing: 12) {
+                ForEach(Appearance.allCases) { mode in
+                    VStack(spacing: 6) {
+                        themePreview(for: mode)
+                            .frame(width: 100, height: 70)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(mode == appearance ? accent.color : .clear, lineWidth: 3)
+                            )
+                            .onTapGesture {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    appearanceRaw = mode.rawValue
+                                }
+                            }
+
+                        Text(mode.label)
+                            .font(.system(size: 16, weight: .regular, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.8))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(.top, 8)
+
+            Text("Accent color")
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white)
+                .padding(.top, 20)
+
+            HStack(spacing: 16) {
+                ForEach(AccentColorOption.allCases) { option in
+                    Circle()
+                        .fill(option.color)
+                        .frame(width: 28, height: 28)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white, lineWidth: option == accent ? 3 : 0)
+                        )
+                        .onTapGesture {
+                            accentRaw = option.rawValue
+                        }
+                }
+            }
+        }
+    }
+
+    private var interactionsSection: some View {
+        settingsBox {
+            Text("Interactions")
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            Toggle(isOn: $hapticsEnabled) {
+                Text("Vibration")
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+
+            Toggle(isOn: $soundsEnabled) {
+                Text("Sounds")
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+
+            Toggle(isOn: $confirmationsEnabled) {
+                Text("Confirmations")
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        settingsBox {
+            Text("About")
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            HStack {
+                Text("Version")
+                Spacer()
+                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+            }
+            .foregroundStyle(.white.opacity(0.8))
+
+            Button {
+                if let url = URL(string: "mailto:support@example.com") {
+                    openURL(url)
+                }
+            } label: {
+                Text("Send Feedback")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(accent.color.opacity(0.25))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .padding(.top, 12)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func themePreview(for mode: Appearance) -> some View {
+        switch mode {
+        case .light:
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white)
+        case .dark:
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.black)
+        case .system:
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(
+                    LinearGradient(colors: [.black, .white], startPoint: .leading, endPoint: .trailing)
+                )
+        }
+    }
+
+    private func settingsBox<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            content()
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(Color.white.opacity(0.07))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
+                .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+        )
+        .padding(.horizontal, 22)
+    }
+}
+
+#Preview {
+    SettingsView()
+        .background(Color.black)
+        .preferredColorScheme(.dark)
+}
+


### PR DESCRIPTION
## Summary
- Add models for appearance and accent color options and store selections using `@AppStorage`
- Implement SettingsView with theme previews, accent color picker, interaction toggles, and about section
- Apply chosen theme and accent color across the app, including background gradients and tab bar

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c616325e10832093d5629f50c2cab6