### PR TITLE
Add animated theme and accent transitions

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -9,6 +9,8 @@ struct BottomSheetGallery: View {
     @Binding var selectedAsset: PHAsset?
 
     private let columns: [GridItem] = Array(repeating: .init(.flexible(), spacing: 16, alignment: .center), count: 3)
+    @Environment(\.colorScheme) private var colorScheme
+    private var primary: Color { colorScheme == .dark ? .white : .black }
 
     var body: some View {
         let grouped = Dictionary(grouping: assets) { asset in
@@ -21,7 +23,7 @@ struct BottomSheetGallery: View {
                     Section(header:
                         Text(dateFormatted(date))
                             .font(.system(size: 18, weight: .bold, design: .rounded))
-                            .foregroundStyle(.white.opacity(0.85))
+                            .foregroundStyle(primary.opacity(0.85))
                             .padding(.leading, 6)
                             .padding(.bottom, 4)
                             .shadow(color: .black.opacity(0.9), radius: 4, x: 0, y: -1)
@@ -68,6 +70,8 @@ struct BottomSheetGallery: View {
         @State private var image: UIImage?
         @State private var durationText: String = ""
         @State private var hasAppeared = false
+        @Environment(\.colorScheme) private var colorScheme
+        private var primary: Color { colorScheme == .dark ? .white : .black }
 
         var body: some View {
             // Image or placeholder
@@ -79,7 +83,7 @@ struct BottomSheetGallery: View {
                             .scaledToFill()
                     } else {
                         RoundedRectangle(cornerRadius: 26, style: .continuous)
-                            .fill(Color.white.opacity(0.08))
+                            .fill(primary.opacity(0.08))
                     }
                 }
             }
@@ -88,12 +92,12 @@ struct BottomSheetGallery: View {
             // Border
             .overlay(
                 RoundedRectangle(cornerRadius: 26, style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
+                    .strokeBorder(primary.opacity(0.15), lineWidth: 1)
             )
             // Selection highlight
             .overlay(
                 RoundedRectangle(cornerRadius: 26, style: .continuous)
-                    .stroke(Color.white, lineWidth: isSelected ? 4 : 0)
+                    .stroke(primary, lineWidth: isSelected ? 4 : 0)
                     .animation(.easeInOut(duration: 0.25), value: isSelected)
             )
             // Duration label anchored to the *frame*, independent of the cropped image.
@@ -102,7 +106,7 @@ struct BottomSheetGallery: View {
                     Text(durationText)
                         .font(.system(size: 15, weight: .bold, design: .rounded))
                         .padding(8)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(primary)
                         .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
                 }
             }

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -3,33 +3,36 @@ import SwiftUI
 struct RecentRow: View {
     let item: RecentItem
 
+    @Environment(\.colorScheme) private var colorScheme
+    private var primary: Color { colorScheme == .dark ? .white : .black }
+
     var body: some View {
         HStack(spacing: 16) {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.14))
+                .fill(primary.opacity(0.14))
                 .frame(width: 56, height: 56)
                 .overlay(
                     Image(systemName: "waveform")
                         .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.9))
+                        .foregroundStyle(primary.opacity(0.9))
                 )
                 .shadow(color: .black.opacity(0.45), radius: 12, x: 0, y: 6)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
                     .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Text(item.duration)
                     .font(.system(size: 14, weight: .regular))
-                    .foregroundStyle(.white.opacity(0.8))
+                    .foregroundStyle(primary.opacity(0.8))
             }
             Spacer()
             Button(action: { /* TODO: share/download */ }) {
                 Image(systemName: "square.and.arrow.down")
                     .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primary)
                     .padding(10)
             }
             .buttonStyle(.plain)
@@ -38,14 +41,14 @@ struct RecentRow: View {
         .padding(.vertical, 12)
         .background(
             RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.white.opacity(0.16))
+                .fill(primary.opacity(0.16))
                 .overlay(
                     RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                 )
         )
         .shadow(color: .black.opacity(0.55), radius: 18, x: 0, y: 10)
-        .shadow(color: .white.opacity(0.06), radius: 1, x: 0, y: 1)
+        .shadow(color: colorScheme == .dark ? Color.white.opacity(0.06) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
     }
 }
 

--- a/Resonans/ResonansApp.swift
+++ b/Resonans/ResonansApp.swift
@@ -16,6 +16,7 @@ struct ResonansApp: App {
         WindowGroup {
             ContentView()
                 .preferredColorScheme(appearance.colorScheme)
+                .animation(.easeInOut(duration: 0.4), value: appearanceRaw)
         }
     }
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -33,9 +33,13 @@ struct ContentView: View {
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
+    @Environment(\.colorScheme) private var colorScheme
+    private var background: Color { colorScheme == .dark ? .black : .white }
+    private var primary: Color { colorScheme == .dark ? .white : .black }
+
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            background.ignoresSafeArea()
                 .overlay(
                     LinearGradient(colors: [accent.gradient, .clear], startPoint: .topLeading, endPoint: .bottom)
                         .ignoresSafeArea()
@@ -59,7 +63,7 @@ struct ContentView: View {
                                 if assets.isEmpty {
                                     Text("None yet")
                                         .font(.system(size: 18, weight: .regular, design: .rounded))
-                                        .foregroundStyle(.white.opacity(0.6))
+                                        .foregroundStyle(primary.opacity(0.6))
                                         .padding(.top, 60)
                                 } else {
                                     BottomSheetGallery(
@@ -89,8 +93,8 @@ struct ContentView: View {
                     .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
                     .animation(.easeInOut(duration: 0.3), value: selectedTab)
                     .overlay(
-                        LinearGradient(
-                            gradient: Gradient(colors: [Color.black, Color.black.opacity(0.0)]),
+                    LinearGradient(
+                            gradient: Gradient(colors: [background, background.opacity(0.0)]),
                             startPoint: .bottom,
                             endPoint: .top
                         )
@@ -108,18 +112,18 @@ struct ContentView: View {
                             }) {
                                 Text("Extract Audio")
                                     .font(.system(size: 18, weight: .semibold, design: .rounded))
-                                    .foregroundColor(.black)
+                                    .foregroundColor(background)
                                     .padding(.horizontal, 24)
                                     .padding(.vertical, 12)
-                                    .background(Color.white)
+                                    .background(primary)
                                     .clipShape(Capsule())
                             }
                             .padding(.bottom, 0)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                         }
                         ZStack {
-                            LinearGradient(
-                                gradient: Gradient(colors: [Color.black, Color.black.opacity(0.0)]),
+                        LinearGradient(
+                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
                                 startPoint: .bottom,
                                 endPoint: .top
                             )
@@ -132,7 +136,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "house.fill")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 0 ? accent.color : Color.white.opacity(0.5))
+                                        .foregroundStyle(selectedTab == 0 ? accent.color : primary.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -141,7 +145,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "photo.on.rectangle.angled")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 1 ? accent.color : Color.white.opacity(0.5))
+                                        .foregroundStyle(selectedTab == 1 ? accent.color : primary.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -150,7 +154,7 @@ struct ContentView: View {
                                 }) {
                                     Image(systemName: "gearshape.fill")
                                         .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 2 ? accent.color : Color.white.opacity(0.5))
+                                        .foregroundStyle(selectedTab == 2 ? accent.color : primary.opacity(0.5))
                                         .animation(.easeInOut(duration: 0.25), value: selectedTab)
                                 }
                                 Spacer()
@@ -169,7 +173,7 @@ struct ContentView: View {
                         Spacer()
                         Text(msg)
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(primary)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 10)
                             .background(toastColor.opacity(0.85))
@@ -190,6 +194,8 @@ struct ContentView: View {
             }
         }
         .tint(accent.color)
+        .animation(.easeInOut(duration: 0.4), value: colorScheme)
+        .animation(.easeInOut(duration: 0.4), value: accent)
         .contentShape(Rectangle())
         .onTapGesture {
             if showSourceOptions {
@@ -232,11 +238,11 @@ struct ContentView: View {
                 Spacer()
                 Text("Conversion settings coming soon")
                     .font(.system(size: 20, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primary)
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .background(Color.black)
+                    .background(background)
         }
     }
 
@@ -256,13 +262,13 @@ struct ContentView: View {
             Text(headerTitle)
                 .font(.system(size: 46, weight: .heavy, design: .rounded))
                 .tracking(0.5)
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
                 .padding(.leading, 22)
             Spacer()
             Button(action: { /* TODO: show help */ }) {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primary)
                     .shadow(color: .black.opacity(0.8), radius: 4, x: 0, y: 1)
             }
             .buttonStyle(.plain)
@@ -276,7 +282,7 @@ struct ContentView: View {
             let targetWidth = (fullWidth - 16) / 2
             ZStack {
                 if showSourceOptions {
-                    Color.black.opacity(0.001)
+                    background.opacity(0.001)
                         .onTapGesture {
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 showSourceOptions = false
@@ -286,21 +292,21 @@ struct ContentView: View {
                 // Large rectangle (plus)
                 ZStack {
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .fill(Color.white.opacity(0.09))
+                        .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 14) {
                                 Image(systemName: "plus")
                                     .font(.system(size: 56, weight: .bold))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                                 Text("Click to Extract Audio")
                                     .font(.system(size: 24, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                                 
                             }
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 30, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: fullWidth, height: 165)
                         .shadow(color: .black.opacity(0.65), radius: 26, x: 0, y: 20)
@@ -321,20 +327,20 @@ struct ContentView: View {
                 HStack(spacing: 16) {
                     // Files rectangle
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .fill(Color.white.opacity(0.09))
+                        .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 8) {
                                 Image(systemName: "doc.fill")
                                     .font(.system(size: 36, weight: .bold))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                                 Text("Files")
                                     .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                             }
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 30, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
                         .shadow(color: .black.opacity(0.65), radius: 26, x: 0, y: 20)
@@ -347,20 +353,20 @@ struct ContentView: View {
                         }
                     // Gallery rectangle
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .fill(Color.white.opacity(0.09))
+                        .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 8) {
                                 Image(systemName: "photo.on.rectangle.angled")
                                     .font(.system(size: 36, weight: .bold))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                                 Text("Gallery")
                                     .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(primary)
                             }
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 30, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
                         .shadow(color: .black.opacity(0.65), radius: 26, x: 0, y: 20)
@@ -400,7 +406,7 @@ struct ContentView: View {
             // Title inside the box
             Text("Recent extractions")
                 .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
                 .padding(.top, 16)
                 .padding(.horizontal, 20)
 
@@ -408,7 +414,7 @@ struct ContentView: View {
                 if recents.isEmpty {
                     Text("None yet")
                         .font(.system(size: 18, weight: .regular, design: .rounded))
-                        .foregroundStyle(.white.opacity(0.6))
+                        .foregroundStyle(primary.opacity(0.6))
                         .frame(maxWidth: .infinity, alignment: .center)
                 } else {
                     ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
@@ -423,7 +429,7 @@ struct ContentView: View {
                         }) {
                             Text(showAllRecents ? "Show less" : "Show more")
                                 .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                .foregroundStyle(.white.opacity(0.8))
+                                .foregroundStyle(primary.opacity(0.8))
                         }
                         .padding(.top, 4)
                     }
@@ -435,10 +441,10 @@ struct ContentView: View {
         }
         .background(
             RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .fill(Color.white.opacity(0.07))
+                .fill(primary.opacity(0.07))
                 .overlay(
                     RoundedRectangle(cornerRadius: 28, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
                 .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -15,8 +15,10 @@ struct SettingsView: View {
     private var accent: AccentColorOption {
         AccentColorOption(rawValue: accentRaw) ?? .purple
     }
-
     @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var primary: Color { colorScheme == .dark ? .white : .black }
 
     var body: some View {
         ScrollView {
@@ -35,7 +37,7 @@ struct SettingsView: View {
         settingsBox {
             Text("Appearance")
                 .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
 
             HStack(spacing: 12) {
                 ForEach(Appearance.allCases) { mode in
@@ -57,7 +59,7 @@ struct SettingsView: View {
                         }
                         Text(mode.label)
                             .font(.system(size: 16, weight: .regular, design: .rounded))
-                            .foregroundStyle(.white.opacity(0.8))
+                            .foregroundStyle(primary.opacity(0.8))
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -66,14 +68,14 @@ struct SettingsView: View {
 
             Text("Accent color")
                 .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
                 .padding(.top, 20)
 
             HStack(spacing: 16) {
                 ForEach(AccentColorOption.allCases) { option in
                     ZStack {
                         Circle()
-                            .stroke(Color.white, lineWidth: option == accent ? 3 : 0)
+                            .stroke(primary, lineWidth: option == accent ? 3 : 0)
                             .frame(width: 28, height: 28)
                             .scaleEffect(option == accent ? 1.3 : 1.0)
                             .animation(.easeInOut(duration: 0.25), value: accent)
@@ -83,7 +85,9 @@ struct SettingsView: View {
                     }
                     .animation(.easeInOut(duration: 0.25), value: accent)
                     .onTapGesture {
-                        accentRaw = option.rawValue
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            accentRaw = option.rawValue
+                        }
                     }
                 }
             }
@@ -94,21 +98,21 @@ struct SettingsView: View {
         settingsBox {
             Text("Interactions")
                 .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
 
             Toggle(isOn: $hapticsEnabled) {
                 Text("Vibration")
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(primary.opacity(0.9))
             }
 
             Toggle(isOn: $soundsEnabled) {
                 Text("Sounds")
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(primary.opacity(0.9))
             }
 
             Toggle(isOn: $confirmationsEnabled) {
                 Text("Confirmations")
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(primary.opacity(0.9))
             }
         }
     }
@@ -117,14 +121,14 @@ struct SettingsView: View {
         settingsBox {
             Text("About")
                 .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
+                .foregroundStyle(primary)
 
             HStack {
                 Text("Version")
                 Spacer()
                 Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
             }
-            .foregroundStyle(.white.opacity(0.8))
+            .foregroundStyle(primary.opacity(0.8))
 
             Button {
                 if let url = URL(string: "mailto:support@example.com") {
@@ -133,7 +137,7 @@ struct SettingsView: View {
             } label: {
                 Text("Send Feedback")
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(primary)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
                     .background(accent.color.opacity(0.25))
@@ -177,13 +181,13 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .fill(Color.white.opacity(0.07))
+                .fill(primary.opacity(0.07))
                 .overlay(
                     RoundedRectangle(cornerRadius: 28, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
-                .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+                .shadow(color: colorScheme == .dark ? Color.white.opacity(0.05) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
         )
         .padding(.horizontal, 22)
     }


### PR DESCRIPTION
## Summary
- Support light and dark themes with dynamic colors across core views and components
- Animate transitions when switching app appearance or accent colors

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme Resonans -project Resonans.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61c8ac2388320877b7f5eaebe7d99