### PR TITLE
Add conditional top divider and global haptics

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -113,6 +113,7 @@ struct BottomSheetGallery: View {
             .contentShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
             .scaleEffect(hasAppeared ? 1 : 0.8)
             .onTapGesture {
+                HapticsManager.shared.pulse()
                 withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
                     tapAction()
                 }

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -29,7 +29,10 @@ struct RecentRow: View {
                     .foregroundStyle(primary.opacity(0.8))
             }
             Spacer()
-            Button(action: { /* TODO: share/download */ }) {
+            Button(action: {
+                HapticsManager.shared.pulse()
+                /* TODO: share/download */
+            }) {
                 Image(systemName: "square.and.arrow.down")
                     .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(primary)

--- a/Resonans/HapticsManager.swift
+++ b/Resonans/HapticsManager.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+final class HapticsManager {
+    static let shared = HapticsManager()
+    private init() {}
+
+    /// Triggers a haptic feedback if the user enabled vibrations in settings.
+    /// - Parameter style: The impact style to use. Defaults to `.light`.
+    func pulse(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        let defaults = UserDefaults.standard
+        let enabled = defaults.object(forKey: "hapticsEnabled") == nil ? true : defaults.bool(forKey: "hapticsEnabled")
+        guard enabled else { return }
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+}
+

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -66,23 +66,23 @@ struct ContentView: View {
                                     Color.clear.frame(height: 0).id("top")
                                     Spacer(minLength: 0)
                                     addCard
+                                        .background(
+                                            GeometryReader { geo -> Color in
+                                                DispatchQueue.main.async {
+                                                    let show = geo.frame(in: .named("homeScroll")).minY < 0
+                                                    if showHomeTopBorder != show {
+                                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                                            showHomeTopBorder = show
+                                                        }
+                                                    }
+                                                }
+                                                return Color.clear
+                                            }
+                                        )
                                     recentSection
                                     Spacer(minLength: 40)
                                     // statusMessage removed
                                 }
-                                .background(
-                                    GeometryReader { geo -> Color in
-                                        DispatchQueue.main.async {
-                                            let show = geo.frame(in: .named("homeScroll")).minY < 0
-                                            if showHomeTopBorder != show {
-                                                withAnimation(.easeInOut(duration: 0.2)) {
-                                                    showHomeTopBorder = show
-                                                }
-                                            }
-                                        }
-                                        return Color.clear
-                                    }
-                                )
                             }
                             .coordinateSpace(name: "homeScroll")
                             .overlay(alignment: .top) {
@@ -122,7 +122,8 @@ struct ContentView: View {
                                 .background(
                                     GeometryReader { geo -> Color in
                                         DispatchQueue.main.async {
-                                            let show = geo.frame(in: .named("libraryScroll")).minY < 0
+                                            let topPadding: CGFloat = assets.isEmpty ? 60 : 20
+                                            let show = geo.frame(in: .named("libraryScroll")).minY < -topPadding
                                             if showLibraryTopBorder != show {
                                                 withAnimation(.easeInOut(duration: 0.2)) {
                                                     showLibraryTopBorder = show
@@ -177,6 +178,7 @@ struct ContentView: View {
                         Spacer()
                         if selectedAsset != nil {
                             Button(action: {
+                                HapticsManager.shared.pulse()
                                 showConversionSheet = true
                                 convert()
                             }) {
@@ -202,6 +204,7 @@ struct ContentView: View {
                             HStack {
                                 Spacer()
                                 Button(action: {
+                                    HapticsManager.shared.pulse()
                                     if selectedTab == 0 {
                                         homeScrollTrigger.toggle()
                                     } else {
@@ -218,6 +221,7 @@ struct ContentView: View {
                                 }
                                 Spacer()
                                 Button(action: {
+                                    HapticsManager.shared.pulse()
                                     if selectedTab == 1 {
                                         libraryScrollTrigger.toggle()
                                     } else {
@@ -234,6 +238,7 @@ struct ContentView: View {
                                 }
                                 Spacer()
                                 Button(action: {
+                                    HapticsManager.shared.pulse()
                                     if selectedTab == 2 {
                                         settingsScrollTrigger.toggle()
                                     } else {
@@ -289,6 +294,7 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.4), value: accent)
         .contentShape(Rectangle())
         .onTapGesture {
+            HapticsManager.shared.pulse()
             if showSourceOptions {
                 withAnimation(.easeInOut(duration: 0.35)) {
                     showSourceOptions = false
@@ -356,7 +362,10 @@ struct ContentView: View {
             .shadow(color: shadowColor.opacity(0.8), radius: 4, x: 0, y: 1)
             .animation(.easeInOut(duration: 0.25), value: selectedTab)
             Spacer()
-            Button(action: { /* TODO: show help */ }) {
+            Button(action: {
+                HapticsManager.shared.pulse()
+                /* TODO: show help */
+            }) {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(primary)
@@ -375,6 +384,7 @@ struct ContentView: View {
                 if showSourceOptions {
                     background.opacity(0.001)
                         .onTapGesture {
+                            HapticsManager.shared.pulse()
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 showSourceOptions = false
                             }
@@ -403,6 +413,7 @@ struct ContentView: View {
                         .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
                         .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
                         .onTapGesture {
+                            HapticsManager.shared.pulse()
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 showSourceOptions = true
                             }
@@ -437,6 +448,7 @@ struct ContentView: View {
                         .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
                         .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
                         .onTapGesture {
+                            HapticsManager.shared.pulse()
                             showFilePicker = true
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 showSourceOptions = false
@@ -463,6 +475,7 @@ struct ContentView: View {
                         .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
                         .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
                         .onTapGesture {
+                            HapticsManager.shared.pulse()
                             selectedTab = 1
                             withAnimation(.easeInOut(duration: 0.35)) {
                                 showSourceOptions = false
@@ -514,6 +527,7 @@ struct ContentView: View {
                     }
                     if recents.count > 3 {
                         Button(action: {
+                            HapticsManager.shared.pulse()
                             withAnimation(.easeInOut(duration: 0.25)) {
                                 showAllRecents.toggle()
                             }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -36,7 +36,7 @@ struct SettingsView: View {
                 .background(
                     GeometryReader { geo -> Color in
                         DispatchQueue.main.async {
-                            let show = geo.frame(in: .named("settingsScroll")).minY < 0
+                            let show = geo.frame(in: .named("settingsScroll")).minY < -30
                             if showTopBorder != show {
                                 withAnimation(.easeInOut(duration: 0.2)) {
                                     showTopBorder = show
@@ -85,6 +85,7 @@ struct SettingsView: View {
                                 .animation(.easeInOut(duration: 0.3), value: appearance)
                         }
                         .onTapGesture {
+                            HapticsManager.shared.pulse()
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 appearanceRaw = mode.rawValue
                             }
@@ -117,6 +118,7 @@ struct SettingsView: View {
                     }
                     .animation(.easeInOut(duration: 0.25), value: accent)
                     .onTapGesture {
+                        HapticsManager.shared.pulse()
                         withAnimation(.easeInOut(duration: 0.3)) {
                             accentRaw = option.rawValue
                         }
@@ -136,15 +138,24 @@ struct SettingsView: View {
                 Text("Vibration")
                     .foregroundStyle(primary.opacity(0.9))
             }
+            .onChange(of: hapticsEnabled) { _ in
+                HapticsManager.shared.pulse()
+            }
 
             Toggle(isOn: $soundsEnabled) {
                 Text("Sounds")
                     .foregroundStyle(primary.opacity(0.9))
             }
+            .onChange(of: soundsEnabled) { _ in
+                HapticsManager.shared.pulse()
+            }
 
             Toggle(isOn: $confirmationsEnabled) {
                 Text("Confirmations")
                     .foregroundStyle(primary.opacity(0.9))
+            }
+            .onChange(of: confirmationsEnabled) { _ in
+                HapticsManager.shared.pulse()
             }
         }
     }
@@ -163,6 +174,7 @@ struct SettingsView: View {
             .foregroundStyle(primary.opacity(0.8))
 
             Button {
+                HapticsManager.shared.pulse()
                 if let url = URL(string: "mailto:support@example.com") {
                     openURL(url)
                 }


### PR DESCRIPTION
## Summary
- only show the grey divider when content scrolls beneath it in home, library and settings views
- add a centralized haptics manager and trigger vibrations across buttons, toggles and taps when enabled

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eed568188320896a067c4dac53cf