### PR TITLE
Standardize spacing and corner radii across views

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -82,21 +82,21 @@ struct BottomSheetGallery: View {
                             .resizable()
                             .scaledToFill()
                     } else {
-                        RoundedRectangle(cornerRadius: 26, style: .continuous)
+                        RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                             .fill(primary.opacity(0.08))
                     }
                 }
             }
             .frame(width: 100, height: 100)
-            .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous))
             // Border
             .overlay(
-                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                     .strokeBorder(primary.opacity(0.15), lineWidth: 1)
             )
             // Selection highlight
             .overlay(
-                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                     .stroke(primary, lineWidth: isSelected ? 4 : 0)
                     .animation(.easeInOut(duration: 0.25), value: isSelected)
             )
@@ -110,7 +110,7 @@ struct BottomSheetGallery: View {
                         .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
                 }
             }
-            .contentShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous))
             .scaleEffect(hasAppeared ? 1 : 0.8)
             .onTapGesture {
                 HapticsManager.shared.pulse()

--- a/Resonans/DesignConstants.swift
+++ b/Resonans/DesignConstants.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+struct DesignConstants {
+    static let cornerRadius: CGFloat = 28
+    static let horizontalPadding: CGFloat = 22
+    static let sectionSpacing: CGFloat = 24
+    static let verticalPadding: CGFloat = 30
+}

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
                     TabView(selection: $selectedTab) {
                         ScrollViewReader { proxy in
                             ScrollView(.vertical, showsIndicators: false) {
-                                VStack(spacing: 24) {
+                                VStack(spacing: DesignConstants.sectionSpacing) {
                                     Color.clear.frame(height: 0).id("top")
                                     Spacer(minLength: 0)
                                     addCard
@@ -83,6 +83,7 @@ struct ContentView: View {
                                     Spacer(minLength: 40)
                                     // statusMessage removed
                                 }
+                                .padding(.vertical, DesignConstants.verticalPadding)
                             }
                             .coordinateSpace(name: "homeScroll")
                             .overlay(alignment: .top) {
@@ -114,8 +115,8 @@ struct ContentView: View {
                                             onLastItemAppear: loadMoreItems,
                                             selectedAsset: $selectedAsset
                                         )
-                                        .padding(.horizontal, 14)
-                                        .padding(.top, 20)
+                                        .padding(.horizontal, DesignConstants.horizontalPadding)
+                                        .padding(.top, DesignConstants.verticalPadding)
                                     }
                                     Spacer()
                                 }
@@ -378,7 +379,7 @@ struct ContentView: View {
 
     private var addCard: some View {
         GeometryReader { geo in
-            let fullWidth = geo.size.width - 44 // horizontal padding
+            let fullWidth = geo.size.width - (DesignConstants.horizontalPadding * 2)
             let targetWidth = (fullWidth - 16) / 2
             ZStack {
                 if showSourceOptions {
@@ -392,7 +393,7 @@ struct ContentView: View {
                 }
                 // Large rectangle (plus)
                 ZStack {
-                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                         .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 14) {
@@ -406,7 +407,7 @@ struct ContentView: View {
                             }
                         )
                         .overlay(
-                            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                            RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                                 .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: fullWidth, height: 165)
@@ -428,7 +429,7 @@ struct ContentView: View {
                 // Two small rectangles (Files and Gallery)
                 HStack(spacing: 16) {
                     // Files rectangle
-                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                         .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 8) {
@@ -441,7 +442,7 @@ struct ContentView: View {
                             }
                         )
                         .overlay(
-                            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                            RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                                 .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
@@ -455,7 +456,7 @@ struct ContentView: View {
                             }
                         }
                     // Gallery rectangle
-                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                         .fill(primary.opacity(0.09))
                         .overlay(
                             VStack(spacing: 8) {
@@ -468,7 +469,7 @@ struct ContentView: View {
                             }
                         )
                         .overlay(
-                            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                            RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                                 .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
@@ -489,7 +490,7 @@ struct ContentView: View {
                 .allowsHitTesting(showSourceOptions)
                 .zIndex(showSourceOptions ? 1 : 0)
             }
-            .padding(.horizontal, 22)
+            .padding(.horizontal, DesignConstants.horizontalPadding)
             .frame(height: 165)
             .gesture(
                 DragGesture(minimumDistance: 24, coordinateSpace: .local)
@@ -545,16 +546,16 @@ struct ContentView: View {
             .frame(height: showAllRecents ? nil : 323)
         }
         .background(
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
+            RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                 .fill(primary.opacity(0.07))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                         .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                 )
                 .shadow(color: shadowColor.opacity(0.55), radius: 22, x: 0, y: 14)
                 .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
         )
-        .padding(.horizontal, 22)
+        .padding(.horizontal, DesignConstants.horizontalPadding)
         .padding(.bottom, 120)
     }
 

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -224,16 +224,16 @@ struct SettingsView: View {
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
+            RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                 .fill(primary.opacity(0.07))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    RoundedRectangle(cornerRadius: DesignConstants.cornerRadius, style: .continuous)
                         .strokeBorder(primary.opacity(0.10), lineWidth: 1)
                 )
                 .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
                 .shadow(color: colorScheme == .dark ? Color.white.opacity(0.05) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
         )
-        .padding(.horizontal, 22)
+        .padding(.horizontal, DesignConstants.horizontalPadding)
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize design values (corner radius, padding, spacing) in `DesignConstants`
- apply shared constants across ContentView, SettingsView and gallery thumbnails for uniform layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c72893a3ec8320a6ba4b6b905476c0