### PR TITLE
Disable ScrollView overscroll

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -273,6 +273,7 @@ struct ContentView: View {
                 }
                 .padding(.top, AppStyle.innerPadding)
             }
+            .scrollBounceBehavior(.never)
             .coordinateSpace(name: "homeScroll")
             .overlay(alignment: .top) {
                 Rectangle()
@@ -325,6 +326,7 @@ struct ContentView: View {
                     }
                 )
             }
+            .scrollBounceBehavior(.never)
             .coordinateSpace(name: "libraryScroll")
             .overlay(alignment: .top) {
                 Rectangle()

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -47,6 +47,7 @@ struct SettingsView: View {
                     }
                 )
             }
+            .scrollBounceBehavior(.never)
             .coordinateSpace(name: "settingsScroll")
             .overlay(alignment: .top) {
                 Rectangle()


### PR DESCRIPTION
## Summary
- disable bounce on home, library, and settings scroll views to cap upward scrolling

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c72c72be148320b23aabde5598da64