### PR TITLE
Fix overscroll past top in scroll views

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -253,7 +253,9 @@ struct ContentView: View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 24) {
-                    Color.clear.frame(height: 0).id("top")
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .id("top")
                     addCard
                         .background(
                             GeometryReader { geo -> Color in
@@ -271,7 +273,6 @@ struct ContentView: View {
                     recentSection
                     Spacer(minLength: 40)
                 }
-                .padding(.top, AppStyle.innerPadding)
             }
             .coordinateSpace(name: "homeScroll")
             .overlay(alignment: .top) {
@@ -293,12 +294,14 @@ struct ContentView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack {
-                    Color.clear.frame(height: 0).id("top")
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .id("top")
                     if assets.isEmpty {
                         Text("None yet")
                             .font(.system(size: 18, weight: .regular, design: .rounded))
                             .foregroundStyle(primary.opacity(0.6))
-                            .padding(.top, 60)
+                            .padding(.top, 40)
                     } else {
                         BottomSheetGallery(
                             assets: Array(assets.prefix(displayedItemCount)),
@@ -306,7 +309,6 @@ struct ContentView: View {
                             selectedAsset: $selectedAsset
                         )
                         .padding(.horizontal, AppStyle.horizontalPadding)
-                        .padding(.top, AppStyle.innerPadding)
                     }
                     Spacer()
                 }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -26,13 +26,15 @@ struct SettingsView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 24) {
-                    Color.clear.frame(height: 0).id("top")
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .id("top")
                     appearanceSection
                     interactionsSection
                     aboutSection
                     Spacer(minLength: 120)
                 }
-                .padding(.vertical, AppStyle.innerPadding)
+                .padding(.bottom, AppStyle.innerPadding)
                 .background(
                     GeometryReader { geo -> Color in
                         DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- prevent scrolling above intended top in home and library views
- remove top padding from settings scroll view

## Testing
- `xcodebuild -project Resonans.xcodeproj -scheme Resonans -sdk iphonesimulator build` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c72da17b0c8320a1df1e1cdb13197d