### PR TITLE
Improve haptic feedback and add cache clearing

### DIFF
--- a/Resonans/CacheManager.swift
+++ b/Resonans/CacheManager.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class CacheManager {
+    static let shared = CacheManager()
+    private init() {}
+
+    /// Clears any cached network responses.
+    func clear() {
+        URLCache.shared.removeAllCachedResponses()
+    }
+}

--- a/Resonans/HapticsManager.swift
+++ b/Resonans/HapticsManager.swift
@@ -7,12 +7,32 @@ final class HapticsManager {
     /// Triggers a haptic feedback if the user enabled vibrations in settings.
     /// - Parameter style: The impact style to use. Defaults to `.light`.
     func pulse(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
-        let defaults = UserDefaults.standard
-        let enabled = defaults.object(forKey: "hapticsEnabled") == nil ? true : defaults.bool(forKey: "hapticsEnabled")
-        guard enabled else { return }
+        guard hapticsEnabled else { return }
         let generator = UIImpactFeedbackGenerator(style: style)
         generator.prepare()
         generator.impactOccurred()
+    }
+
+    /// Provides a subtle selection change feedback.
+    func selection() {
+        guard hapticsEnabled else { return }
+        let generator = UISelectionFeedbackGenerator()
+        generator.prepare()
+        generator.selectionChanged()
+    }
+
+    /// Provides a notification style feedback (success, warning, error).
+    /// - Parameter type: The notification feedback type.
+    func notify(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        guard hapticsEnabled else { return }
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+
+    private var hapticsEnabled: Bool {
+        let defaults = UserDefaults.standard
+        return defaults.object(forKey: "hapticsEnabled") == nil ? true : defaults.bool(forKey: "hapticsEnabled")
     }
 }
 

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -198,12 +198,13 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.4), value: accent)
         .contentShape(Rectangle())
         .onTapGesture {
-            HapticsManager.shared.pulse()
             if showSourceOptions {
+                HapticsManager.shared.selection()
                 withAnimation(.easeInOut(duration: 0.35)) {
                     showSourceOptions = false
                 }
             } else if selectedAsset != nil {
+                HapticsManager.shared.pulse(.medium)
                 withAnimation {
                     selectedAsset = nil
                 }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -142,7 +142,7 @@ struct SettingsView: View {
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: hapticsEnabled) { _ in
-                HapticsManager.shared.pulse()
+                HapticsManager.shared.selection()
             }
 
             Toggle(isOn: $soundsEnabled) {
@@ -150,7 +150,7 @@ struct SettingsView: View {
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: soundsEnabled) { _ in
-                HapticsManager.shared.pulse()
+                HapticsManager.shared.selection()
             }
 
             Toggle(isOn: $confirmationsEnabled) {
@@ -158,8 +158,25 @@ struct SettingsView: View {
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: confirmationsEnabled) { _ in
-                HapticsManager.shared.pulse()
+                HapticsManager.shared.selection()
             }
+
+            Divider()
+                .padding(.vertical, 8)
+
+            Button {
+                CacheManager.shared.clear()
+                HapticsManager.shared.notify(.success)
+            } label: {
+                Text("Clear Cache")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(accent.color.opacity(0.25))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .padding(.top, 4)
         }
     }
 


### PR DESCRIPTION
## Summary
- Refine global tap handler to vibrate only on interactions and with context-appropriate feedback
- Add clear cache control in settings backed by a new cache manager
- Expand haptics utilities to support selection and notification feedback styles

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c732416ef8832091c8c16b6e02decc