### PR TITLE
Add video preview controls and defer extraction

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import AVKit
 import Photos
 
 struct ContentView: View {
@@ -36,6 +37,10 @@ struct ContentView: View {
     @State private var showHomeTopBorder = false
     @State private var showGalleryTopBorder = false
 
+    @State private var previewPlayer: AVPlayer?
+    @State private var isPreviewPlaying = false
+    @State private var showPreviewControls = false
+
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
@@ -46,7 +51,7 @@ struct ContentView: View {
     private var shadowColor: Color { colorScheme == .light ? .white : .black }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topLeading) {
             background.ignoresSafeArea()
                 .overlay(
                     LinearGradient(
@@ -84,7 +89,9 @@ struct ContentView: View {
                             Button(action: {
                                 HapticsManager.shared.pulse()
                                 showConversionSheet = true
-                                convert()
+                                stopPreview()
+                                showPreviewControls = false
+                                withAnimation { selectedAsset = nil }
                             }) {
                                 Text("Extract Audio")
                                     .font(.system(size: 18, weight: .semibold, design: .rounded))
@@ -166,6 +173,31 @@ struct ContentView: View {
                     }
                 }
             }
+            if showPreviewControls, let player = previewPlayer {
+                VStack(alignment: .leading, spacing: 8) {
+                    if isPreviewPlaying {
+                        VideoPlayer(player: player)
+                            .frame(width: 200, height: 150)
+                            .clipShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
+                    }
+                    Button(action: {
+                        if isPreviewPlaying {
+                            player.pause()
+                        } else {
+                            player.play()
+                        }
+                        isPreviewPlaying.toggle()
+                    }) {
+                        Image(systemName: isPreviewPlaying ? "pause.fill" : "play.fill")
+                            .font(.system(size: 20, weight: .bold))
+                            .foregroundStyle(background)
+                            .padding(10)
+                            .background(primary.opacity(0.8))
+                            .clipShape(Circle())
+                    }
+                }
+                .padding()
+            }
             // Toast overlay at the very top
             if showToast, let msg = message {
                 VStack {
@@ -220,19 +252,46 @@ struct ContentView: View {
                 withAnimation { selectedAsset = nil }
             }
         }
+        .onChange(of: selectedAsset) { asset in
+            if let asset = asset {
+                let options = PHVideoRequestOptions()
+                options.isNetworkAccessAllowed = true
+                PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
+                    if let urlAsset = avAsset as? AVURLAsset {
+                        DispatchQueue.main.async {
+                            stopPreview()
+                            videoURL = urlAsset.url
+                            previewPlayer = AVPlayer(url: urlAsset.url)
+                            showPreviewControls = true
+                            isPreviewPlaying = false
+                        }
+                    }
+                }
+            } else {
+                stopPreview()
+                previewPlayer = nil
+                showPreviewControls = false
+            }
+        }
         // Removed unused .confirmationDialog
         .sheet(isPresented: $showPhotoPicker) {
             VideoPicker { url in
+                stopPreview()
                 videoURL = url
+                previewPlayer = AVPlayer(url: url)
+                showPreviewControls = true
+                isPreviewPlaying = false
                 showConversionSheet = true
-                convert()
             }
         }
         .sheet(isPresented: $showFilePicker) {
             FilePicker { url in
+                stopPreview()
                 videoURL = url
+                previewPlayer = AVPlayer(url: url)
+                showPreviewControls = true
+                isPreviewPlaying = false
                 showConversionSheet = true
-                convert()
             }
         }
         .sheet(isPresented: $showConversionSheet) {
@@ -620,6 +679,11 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    private func stopPreview() {
+        previewPlayer?.pause()
+        isPreviewPlaying = false
     }
 
     private func loadMoreItems() {


### PR DESCRIPTION
## Summary
- Delay audio extraction until future conversion screen
- Deselect gallery item after tapping Extract Audio but remember selection
- Add top-left play button to preview selected video

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c757072f64832097a2b07a305bbe56