### PR TITLE
Inline video previews in gallery

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -70,20 +70,31 @@ struct BottomSheetGallery: View {
         @State private var image: UIImage?
         @State private var durationText: String = ""
         @State private var hasAppeared = false
+        @State private var player: AVPlayer?
+        @State private var isPlaying = false
+        @State private var currentTime: Double = 0
+        @State private var timeObserver: Any?
+        @State private var endObserver: NSObjectProtocol?
         @Environment(\.colorScheme) private var colorScheme
         private var primary: Color { colorScheme == .dark ? .white : .black }
 
         var body: some View {
             // Image or placeholder
             ZStack {
-                Group {
-                    if let image = image {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFill()
-                    } else {
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .fill(primary.opacity(0.08))
+                if isSelected, let player = player {
+                    PlayerView(player: player)
+                        .scaledToFill()
+                        .clipped()
+                } else {
+                    Group {
+                        if let image = image {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                .fill(primary.opacity(0.08))
+                        }
                     }
                 }
             }
@@ -100,14 +111,48 @@ struct BottomSheetGallery: View {
                     .stroke(primary, lineWidth: isSelected ? 4 : 0)
                     .animation(.easeInOut(duration: 0.25), value: isSelected)
             )
-            // Duration label anchored to the *frame*, independent of the cropped image.
+            // Progress or original duration label
             .overlay(alignment: .bottomLeading) {
-                if !durationText.isEmpty {
+                if isPlaying {
+                    Text(formatDuration(currentTime))
+                        .font(.system(size: 15, weight: .bold, design: .rounded))
+                        .padding(8)
+                        .foregroundColor(.white)
+                        .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
+                } else if !durationText.isEmpty {
                     Text(durationText)
                         .font(.system(size: 15, weight: .bold, design: .rounded))
                         .padding(8)
                         .foregroundColor(.white)
                         .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
+                }
+            }
+            // Play / Pause button
+            .overlay(alignment: .topTrailing) {
+                if isSelected {
+                    Button(action: {
+                        if isPlaying {
+                            player?.pause()
+                            isPlaying = false
+                        } else {
+                            if player == nil {
+                                startPreview()
+                            } else {
+                                player?.play()
+                                addTimeObserver()
+                                addEndObserver()
+                            }
+                            isPlaying = true
+                        }
+                    }) {
+                        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(.white)
+                            .padding(6)
+                            .background(Color.black.opacity(0.6))
+                            .clipShape(Circle())
+                            .padding(4)
+                    }
                 }
             }
             .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
@@ -129,8 +174,16 @@ struct BottomSheetGallery: View {
                     }
                 }
             }
+            .onChange(of: isSelected) { newValue in
+                if !newValue {
+                    stopPreview()
+                }
+            }
             .onChange(of: asset.localIdentifier) { _ in
                 loadDuration()
+            }
+            .onDisappear {
+                stopPreview()
             }
         }
 
@@ -184,5 +237,75 @@ struct BottomSheetGallery: View {
             let seconds = totalSeconds % 60
             return String(format: "%02d:%02d", minutes, seconds)
         }
+
+        private func startPreview() {
+            currentTime = 0
+            let options = PHVideoRequestOptions()
+            options.isNetworkAccessAllowed = true
+            PHImageManager.default().requestPlayerItem(forVideo: asset, options: options) { item, _ in
+                DispatchQueue.main.async {
+                    guard isSelected, let item = item else { return }
+                    let player = AVPlayer(playerItem: item)
+                    self.player = player
+                    addTimeObserver()
+                    addEndObserver()
+                    player.play()
+                }
+            }
+        }
+
+        private func stopPreview() {
+            if let player = player {
+                player.pause()
+                if let timeObserver = timeObserver {
+                    player.removeTimeObserver(timeObserver)
+                    self.timeObserver = nil
+                }
+                if let endObserver = endObserver {
+                    NotificationCenter.default.removeObserver(endObserver)
+                    self.endObserver = nil
+                }
+            }
+            currentTime = 0
+            isPlaying = false
+            player = nil
+        }
+
+        private func addTimeObserver() {
+            guard let player = player, timeObserver == nil else { return }
+            let interval = CMTime(seconds: 1, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+            timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { time in
+                currentTime = time.seconds
+            }
+        }
+
+        private func addEndObserver() {
+            guard let player = player, endObserver == nil else { return }
+            endObserver = NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: player.currentItem, queue: .main) { _ in
+                stopPreview()
+            }
+        }
+    }
+}
+
+private struct PlayerView: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> UIView {
+        let view = PlayerContainerView()
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let view = uiView as? PlayerContainerView {
+            view.playerLayer.player = player
+        }
+    }
+
+    private final class PlayerContainerView: UIView {
+        override static var layerClass: AnyClass { AVPlayerLayer.self }
+        var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
     }
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import AVFoundation
-import AVKit
 import Photos
 
 struct ContentView: View {
@@ -37,9 +36,6 @@ struct ContentView: View {
     @State private var showHomeTopBorder = false
     @State private var showGalleryTopBorder = false
 
-    @State private var previewPlayer: AVPlayer?
-    @State private var isPreviewPlaying = false
-    @State private var showPreviewControls = false
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
@@ -89,8 +85,6 @@ struct ContentView: View {
                             Button(action: {
                                 HapticsManager.shared.pulse()
                                 showConversionSheet = true
-                                stopPreview()
-                                showPreviewControls = false
                                 withAnimation { selectedAsset = nil }
                             }) {
                                 Text("Extract Audio")
@@ -173,31 +167,6 @@ struct ContentView: View {
                     }
                 }
             }
-            if showPreviewControls, let player = previewPlayer {
-                VStack(alignment: .leading, spacing: 8) {
-                    if isPreviewPlaying {
-                        VideoPlayer(player: player)
-                            .frame(width: 200, height: 150)
-                            .clipShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
-                    }
-                    Button(action: {
-                        if isPreviewPlaying {
-                            player.pause()
-                        } else {
-                            player.play()
-                        }
-                        isPreviewPlaying.toggle()
-                    }) {
-                        Image(systemName: isPreviewPlaying ? "pause.fill" : "play.fill")
-                            .font(.system(size: 20, weight: .bold))
-                            .foregroundStyle(background)
-                            .padding(10)
-                            .background(primary.opacity(0.8))
-                            .clipShape(Circle())
-                    }
-                }
-                .padding()
-            }
             // Toast overlay at the very top
             if showToast, let msg = message {
                 VStack {
@@ -259,38 +228,24 @@ struct ContentView: View {
                 PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
                     if let urlAsset = avAsset as? AVURLAsset {
                         DispatchQueue.main.async {
-                            stopPreview()
                             videoURL = urlAsset.url
-                            previewPlayer = AVPlayer(url: urlAsset.url)
-                            showPreviewControls = true
-                            isPreviewPlaying = false
                         }
                     }
                 }
             } else {
-                stopPreview()
-                previewPlayer = nil
-                showPreviewControls = false
+                videoURL = nil
             }
         }
         // Removed unused .confirmationDialog
         .sheet(isPresented: $showPhotoPicker) {
             VideoPicker { url in
-                stopPreview()
                 videoURL = url
-                previewPlayer = AVPlayer(url: url)
-                showPreviewControls = true
-                isPreviewPlaying = false
                 showConversionSheet = true
             }
         }
         .sheet(isPresented: $showFilePicker) {
             FilePicker { url in
-                stopPreview()
                 videoURL = url
-                previewPlayer = AVPlayer(url: url)
-                showPreviewControls = true
-                isPreviewPlaying = false
                 showConversionSheet = true
             }
         }
@@ -679,11 +634,6 @@ struct ContentView: View {
                 }
             }
         }
-    }
-
-    private func stopPreview() {
-        previewPlayer?.pause()
-        isPreviewPlaying = false
     }
 
     private func loadMoreItems() {


### PR DESCRIPTION
## Summary
- show elapsed preview time only while video plays
- display play/pause control in thumbnail and start playback on tap
- reset preview and controls after playback completes

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c7592549648320977416ddf22056f5