### PR TITLE
Fix gallery export flow and restyle conversion previews

### DIFF
--- a/Resonans.xcodeproj/project.pbxproj
+++ b/Resonans.xcodeproj/project.pbxproj
@@ -426,7 +426,6 @@
 				INFOPLIST_FILE = Resonans/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Resonans;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "We need access to save exported videos.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "We need access to your photo library to display videos.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -463,7 +462,6 @@
 				INFOPLIST_FILE = Resonans/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Resonans;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "We need access to save exported videos.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "We need access to your photo library to display videos.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -81,9 +81,9 @@ struct ContentView: View {
                         Spacer()
                         if selectedAsset != nil {
                             Button(action: {
+                                guard videoURL != nil else { return }
                                 HapticsManager.shared.pulse()
                                 showConversionSheet = true
-                                withAnimation { selectedAsset = nil }
                             }) {
                                 Text("Extract Audio")
                                     .font(.system(size: 18, weight: .semibold, design: .rounded))
@@ -93,6 +93,8 @@ struct ContentView: View {
                                     .background(primary)
                                     .clipShape(Capsule())
                             }
+                            .disabled(videoURL == nil)
+                            .opacity(videoURL == nil ? 0.6 : 1)
                             .padding(.bottom, 0)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                         }
@@ -230,7 +232,7 @@ struct ContentView: View {
                         }
                     }
                 }
-            } else {
+            } else if !showConversionSheet {
                 videoURL = nil
             }
         }
@@ -247,7 +249,15 @@ struct ContentView: View {
                 showConversionSheet = true
             }
         }
-        .sheet(isPresented: $showConversionSheet) {
+        .sheet(
+            isPresented: $showConversionSheet,
+            onDismiss: {
+                withAnimation {
+                    selectedAsset = nil
+                }
+                videoURL = nil
+            }
+        ) {
             if let url = videoURL {
                 ConversionSettingsView(videoURL: url)
             }


### PR DESCRIPTION
## Summary
- ensure the gallery export button only opens the conversion sheet once the selected video URL is ready and reset the selection on dismiss
- refresh the conversion settings sheet with English copy, forced side-by-side previews, and preview cards that mirror the gallery selection styling
- drop the unused photo library add-permission request from the build settings to avoid export crashes

## Testing
- not run (xcodebuild -scheme Resonans -sdk iphonesimulator build) (Xcode unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb37d09f2483208375e1a40a18f509