### PR TITLE
Improve export stability and refresh preview UI

### DIFF
--- a/Resonans/VideoToAudioConverter.swift
+++ b/Resonans/VideoToAudioConverter.swift
@@ -33,10 +33,10 @@ final class VideoToAudioConverter {
             export(asset: asset, outputURL: out, fileType: .m4a, progress: progress, completion: completion)
         case .wav:
             let out = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
-            export(asset: asset, outputURL: out, fileType: .wav, progress: progress, completion: completion)
+            exportToWAV(asset: asset, outputURL: out, progress: progress, completion: completion)
         case .mp3:
             let wavURL = tmp.appendingPathComponent(baseName).appendingPathExtension(AudioFormat.wav.fileExtension)
-            export(asset: asset, outputURL: wavURL, fileType: .wav, progress: { value in
+            exportToWAV(asset: asset, outputURL: wavURL, progress: { value in
                 progress(value * 0.85)
             }) { result in
                 switch result {
@@ -98,6 +98,128 @@ final class VideoToAudioConverter {
                 }
             default:
                 break
+            }
+        }
+    }
+
+    private static func exportToWAV(
+        asset: AVAsset,
+        outputURL: URL,
+        progress: @escaping (Double) -> Void,
+        completion: @escaping (Result<URL, Error>) -> Void
+    ) {
+        do {
+            if FileManager.default.fileExists(atPath: outputURL.path) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+
+            guard let track = asset.tracks(withMediaType: .audio).first else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "export", code: -4)))
+                }
+                return
+            }
+
+            let reader = try AVAssetReader(asset: asset)
+
+            let formatDescription = track.formatDescriptions.first as? CMAudioFormatDescription
+            let asbd = formatDescription.flatMap { CMAudioFormatDescriptionGetStreamBasicDescription($0)?.pointee }
+            let sampleRate = asbd?.mSampleRate ?? 44_100
+            let channels = Int(asbd?.mChannelsPerFrame ?? 2)
+
+            let pcmSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: channels,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsBigEndianKey: false,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsNonInterleavedKey: false
+            ]
+
+            let readerOutput = AVAssetReaderTrackOutput(track: track, outputSettings: pcmSettings)
+            readerOutput.alwaysCopiesSampleData = false
+            guard reader.canAdd(readerOutput) else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "export", code: -5)))
+                }
+                return
+            }
+            reader.add(readerOutput)
+
+            let writer = try AVAssetWriter(outputURL: outputURL, fileType: .wav)
+            let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: pcmSettings)
+            writerInput.expectsMediaDataInRealTime = false
+            guard writer.canAdd(writerInput) else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "export", code: -6)))
+                }
+                return
+            }
+            writer.add(writerInput)
+
+            guard writer.startWriting() else {
+                throw writer.error ?? NSError(domain: "export", code: -7)
+            }
+
+            let durationSeconds = asset.duration.seconds
+            reader.startReading()
+            writer.startSession(atSourceTime: .zero)
+
+            let queue = DispatchQueue(label: "wav.export.queue")
+            writerInput.requestMediaDataWhenReady(on: queue) {
+                while writerInput.isReadyForMoreMediaData {
+                    if reader.status == .reading, let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                        if !writerInput.append(sampleBuffer) {
+                            reader.cancelReading()
+                            writerInput.markAsFinished()
+                            writer.cancelWriting()
+                            let error = writer.error ?? NSError(domain: "export", code: -8)
+                            DispatchQueue.main.async {
+                                completion(.failure(error))
+                            }
+                            return
+                        }
+
+                        if durationSeconds.isFinite && durationSeconds > 0 {
+                            let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+                            let ratio = min(max(time / durationSeconds, 0), 1)
+                            DispatchQueue.main.async {
+                                progress(ratio)
+                            }
+                        }
+                    } else {
+                        writerInput.markAsFinished()
+                        switch reader.status {
+                        case .completed:
+                            writer.finishWriting {
+                                if let error = writer.error {
+                                    DispatchQueue.main.async {
+                                        completion(.failure(error))
+                                    }
+                                } else {
+                                    DispatchQueue.main.async {
+                                        progress(1)
+                                        completion(.success(outputURL))
+                                    }
+                                }
+                            }
+                        case .failed, .cancelled:
+                            let error = reader.error ?? writer.error ?? NSError(domain: "export", code: -9)
+                            writer.cancelWriting()
+                            DispatchQueue.main.async {
+                                completion(.failure(error))
+                            }
+                        default:
+                            break
+                        }
+                        return
+                    }
+                }
+            }
+        } catch {
+            DispatchQueue.main.async {
+                completion(.failure(error))
             }
         }
     }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -84,6 +84,9 @@ struct ContentView: View {
                                 guard videoURL != nil else { return }
                                 HapticsManager.shared.pulse()
                                 showConversionSheet = true
+                                withAnimation {
+                                    selectedAsset = nil
+                                }
                             }) {
                                 Text("Extract Audio")
                                     .font(.system(size: 18, weight: .semibold, design: .rounded))


### PR DESCRIPTION
## Summary
- replace the WAV export pipeline with an AVAssetReader/Writer implementation so unsupported file types no longer crash the exporter and re-use it for MP3 conversions
- polish the conversion sheet UI by renaming the header, pinning the export button to the bottom inset, and updating the video preview to use a centered play/pause control that resumes from its paused position
- bring the audio preview in line with the video preview by reusing the new playback control, showing duration/progress, and refreshing the styling; clear the gallery selection before opening the converter so previews stop playing

## Testing
- not run (requires Xcode and iOS simulator)


------
https://chatgpt.com/codex/tasks/task_e_68cb3c8bf0b88320a00e6fc10156e8fa