### PR TITLE
Improve export flow and metadata handling

### DIFF
--- a/Resonans/Info.plist
+++ b/Resonans/Info.plist
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict/>
-	</array>
+        <key>CFBundleShortVersionString</key>
+        <string>$(MARKETING_VERSION)</string>
+        <key>CFBundleVersion</key>
+        <string>$(CURRENT_PROJECT_VERSION)</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict/>
+        </array>
 </dict>
 </plist>

--- a/Resonans/VideoToAudioConverter.swift
+++ b/Resonans/VideoToAudioConverter.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import AVFAudio
 import Foundation
 import LAME
 
@@ -20,17 +21,25 @@ final class VideoToAudioConverter {
     static func convert(
         videoURL: URL,
         format: AudioFormat,
+        bitrate: Int,
         progress: @escaping (Double) -> Void,
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
         let asset = AVURLAsset(url: videoURL)
         let baseName = videoURL.deletingPathExtension().lastPathComponent + "_out"
         let tmp = FileManager.default.temporaryDirectory
+        let sanitizedBitrate = max(64, min(320, bitrate))
         progress(0)
         switch format {
         case .m4a:
             let out = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
-            export(asset: asset, outputURL: out, fileType: .m4a, progress: progress, completion: completion)
+            exportToM4A(
+                asset: asset,
+                outputURL: out,
+                bitrate: sanitizedBitrate,
+                progress: progress,
+                completion: completion
+            )
         case .wav:
             let out = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
             exportToWAV(asset: asset, outputURL: out, progress: progress, completion: completion)
@@ -47,7 +56,7 @@ final class VideoToAudioConverter {
                 case .success:
                     do {
                         let mp3URL = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
-                        try wavToMp3(wavURL: wavURL, mp3URL: mp3URL) { encodeProgress in
+                        try wavToMp3(wavURL: wavURL, mp3URL: mp3URL, bitrate: sanitizedBitrate) { encodeProgress in
                             let mapped = 0.85 + (encodeProgress * 0.15)
                             progress(min(max(mapped, 0), 1))
                         }
@@ -67,37 +76,142 @@ final class VideoToAudioConverter {
         }
     }
 
-    private static func export(
+    private static func exportToM4A(
         asset: AVAsset,
         outputURL: URL,
-        fileType: AVFileType,
+        bitrate: Int,
         progress: @escaping (Double) -> Void,
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
-        guard let exporter = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
-            completion(.failure(NSError(domain: "export", code: -1)))
-            return
-        }
-        if FileManager.default.fileExists(atPath: outputURL.path) {
-            try? FileManager.default.removeItem(at: outputURL)
-        }
-        exporter.outputURL = outputURL
-        exporter.outputFileType = fileType
-        let watcher = ExportProgressWatcher(exporter: exporter, progress: progress)
-        exporter.exportAsynchronously {
-            watcher.invalidate()
-            switch exporter.status {
-            case .completed:
+        do {
+            if FileManager.default.fileExists(atPath: outputURL.path) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+
+            guard let track = asset.tracks(withMediaType: .audio).first else {
                 DispatchQueue.main.async {
-                    progress(1)
-                    completion(.success(outputURL))
+                    completion(.failure(NSError(domain: "export", code: -3)))
                 }
-            case .failed, .cancelled:
-                DispatchQueue.main.async {
-                    completion(.failure(exporter.error ?? NSError(domain: "export", code: -2)))
+                return
+            }
+
+            Task {
+                do {
+                    let formatDescriptions: [CMFormatDescription] = try await track.load(.formatDescriptions)
+                    let cmDesc: CMFormatDescription? = formatDescriptions.first
+                    let asbd = cmDesc.flatMap { CMAudioFormatDescriptionGetStreamBasicDescription($0)?.pointee }
+                    let sampleRate = asbd?.mSampleRate ?? 44_100
+                    let channels = Int(asbd?.mChannelsPerFrame ?? 2)
+
+                    let pcmSettings: [String: Any] = [
+                        AVFormatIDKey: kAudioFormatLinearPCM,
+                        AVSampleRateKey: sampleRate,
+                        AVNumberOfChannelsKey: channels,
+                        AVLinearPCMBitDepthKey: 16,
+                        AVLinearPCMIsBigEndianKey: false,
+                        AVLinearPCMIsFloatKey: false,
+                        AVLinearPCMIsNonInterleaved: false
+                    ]
+
+                    let writerSettings: [String: Any] = [
+                        AVFormatIDKey: kAudioFormatMPEG4AAC,
+                        AVSampleRateKey: sampleRate,
+                        AVNumberOfChannelsKey: channels,
+                        AVEncoderBitRateKey: bitrate * 1000,
+                        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+                    ]
+
+                    let reader = try AVAssetReader(asset: asset)
+                    let readerOutput = AVAssetReaderTrackOutput(track: track, outputSettings: pcmSettings)
+                    readerOutput.alwaysCopiesSampleData = false
+                    guard reader.canAdd(readerOutput) else {
+                        DispatchQueue.main.async {
+                            completion(.failure(NSError(domain: "export", code: -4)))
+                        }
+                        return
+                    }
+                    reader.add(readerOutput)
+
+                    let writer = try AVAssetWriter(outputURL: outputURL, fileType: .m4a)
+                    let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: writerSettings)
+                    writerInput.expectsMediaDataInRealTime = false
+                    writerInput.performsMultiPassEncodingIfSupported = true
+                    guard writer.canAdd(writerInput) else {
+                        DispatchQueue.main.async {
+                            completion(.failure(NSError(domain: "export", code: -5)))
+                        }
+                        return
+                    }
+                    writer.add(writerInput)
+
+                    guard writer.startWriting() else {
+                        throw writer.error ?? NSError(domain: "export", code: -6)
+                    }
+
+                    let durationSeconds = asset.duration.seconds
+                    reader.startReading()
+                    writer.startSession(atSourceTime: .zero)
+
+                    let queue = DispatchQueue(label: "m4a.export.queue")
+                    writerInput.requestMediaDataWhenReady(on: queue) {
+                        while writerInput.isReadyForMoreMediaData {
+                            if reader.status == .reading, let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                                if !writerInput.append(sampleBuffer) {
+                                    reader.cancelReading()
+                                    writerInput.markAsFinished()
+                                    writer.cancelWriting()
+                                    let error = writer.error ?? NSError(domain: "export", code: -7)
+                                    DispatchQueue.main.async {
+                                        completion(.failure(error))
+                                    }
+                                    return
+                                }
+
+                                if durationSeconds.isFinite && durationSeconds > 0 {
+                                    let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+                                    let ratio = min(max(time / durationSeconds, 0), 1)
+                                    DispatchQueue.main.async {
+                                        progress(ratio)
+                                    }
+                                }
+                            } else {
+                                writerInput.markAsFinished()
+                                switch reader.status {
+                                case .completed:
+                                    writer.finishWriting {
+                                        if let error = writer.error {
+                                            DispatchQueue.main.async {
+                                                completion(.failure(error))
+                                            }
+                                        } else {
+                                            DispatchQueue.main.async {
+                                                progress(1)
+                                                completion(.success(outputURL))
+                                            }
+                                        }
+                                    }
+                                case .failed, .cancelled:
+                                    let error = reader.error ?? writer.error ?? NSError(domain: "export", code: -8)
+                                    writer.cancelWriting()
+                                    DispatchQueue.main.async {
+                                        completion(.failure(error))
+                                    }
+                                default:
+                                    break
+                                }
+                                return
+                            }
+                        }
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
                 }
-            default:
-                break
+            }
+        } catch {
+            DispatchQueue.main.async {
+                completion(.failure(error))
             }
         }
     }
@@ -236,14 +350,20 @@ final class VideoToAudioConverter {
         }
     }
 
-    private static func wavToMp3(wavURL: URL, mp3URL: URL, progress: @escaping (Double) -> Void) throws {
+    private static func wavToMp3(wavURL: URL, mp3URL: URL, bitrate: Int, progress: @escaping (Double) -> Void) throws {
         guard let pcm = fopen(wavURL.path, "rb") else { throw NSError(domain: "lame", code: -1) }
         defer { fclose(pcm) }
         guard let mp3 = fopen(mp3URL.path, "wb") else { throw NSError(domain: "lame", code: -2) }
         defer { fclose(mp3) }
         guard let lame: OpaquePointer = lame_init() else { throw NSError(domain: "lame", code: -3) }
-        lame_set_in_samplerate(lame, 44100)
-        lame_set_VBR(lame, vbr_default)
+        let audioFile = try AVAudioFile(forReading: wavURL)
+        let format = audioFile.processingFormat
+        lame_set_in_samplerate(lame, Int32(format.sampleRate))
+        lame_set_num_channels(lame, Int32(format.channelCount))
+        lame_set_brate(lame, Int32(bitrate))
+        lame_set_mode(lame, format.channelCount == 1 ? MONO : STEREO)
+        lame_set_VBR(lame, vbr_off)
+        lame_set_quality(lame, 2)
         lame_init_params(lame)
         let pcmBufferSize: Int32 = 8192
         var pcmBuffer = [Int16](repeating: 0, count: Int(pcmBufferSize))
@@ -277,29 +397,3 @@ final class VideoToAudioConverter {
         lame_close(lame)
     }
 }
-
-private final class ExportProgressWatcher {
-    private var timer: DispatchSourceTimer?
-    private weak var exporter: AVAssetExportSession?
-
-    init(exporter: AVAssetExportSession, progress: @escaping (Double) -> Void) {
-        self.exporter = exporter
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
-        timer.schedule(deadline: .now(), repeating: .milliseconds(120))
-        timer.setEventHandler { [weak exporter] in
-            guard let exporter = exporter else { return }
-            let value = min(max(Double(exporter.progress), 0), 1)
-            DispatchQueue.main.async {
-                progress(value)
-            }
-        }
-        timer.resume()
-        self.timer = timer
-    }
-
-    func invalidate() {
-        timer?.cancel()
-        timer = nil
-    }
-}
-

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -17,8 +17,13 @@ struct ConversionSettingsView: View {
     @State private var isProcessing = false
     @State private var progressValue: Double = 0
     @State private var exportURL: URL?
-    @State private var showExporter = false
     @State private var showAdvanced = false
+    @State private var showSuccessSheet = false
+    @State private var audioProperties: AudioProperties?
+    @State private var isLoadingAudioProperties = false
+    @State private var hasLoadedDefaultBitrate = false
+    @State private var userHasAdjustedBitrate = false
+    @State private var didCancelConversion = false
     // Example advanced settings state
     @State private var bitrate: Double = 192 // kbps
     @State private var showBitrateInfo = false
@@ -63,7 +68,7 @@ struct ConversionSettingsView: View {
                 if isProcessing {
                     progressIndicator
                 }
-                exportButton
+                actionButtons
             }
             .padding(.horizontal, AppStyle.horizontalPadding)
             .padding(.top, 12)
@@ -71,11 +76,23 @@ struct ConversionSettingsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(background.opacity(0.95).ignoresSafeArea())
         }
-        .sheet(isPresented: $showExporter, onDismiss: { dismiss() }) {
+        .sheet(isPresented: $showSuccessSheet) {
             if let exportURL = exportURL {
-                ExportPicker(url: exportURL)
+                ConversionSuccessSheet(
+                    url: exportURL,
+                    accentColor: accent.color,
+                    primaryColor: primary,
+                    backgroundColor: background,
+                    onDone: {
+                        showSuccessSheet = false
+                        dismiss()
+                    }
+                )
+                .presentationDetents([.fraction(0.55)])
+                .presentationDragIndicator(.visible)
             }
         }
+        .onAppear(perform: ensureAudioPropertiesLoaded)
     }
 
     // MARK: - Settings Section
@@ -97,7 +114,7 @@ struct ConversionSettingsView: View {
                         Text("Original: \(fileSizeString(for: videoURL))")
                             .font(.system(size: 14))
                             .foregroundStyle(primary.opacity(0.8))
-                        Text("Estimated: \(estimatedExportSizeString())")
+                        Text("Estimated: \(estimatedSizeText)")
                             .font(.system(size: 14))
                             .foregroundStyle(primary.opacity(0.8))
                     }
@@ -195,8 +212,24 @@ struct ConversionSettingsView: View {
                                         .foregroundStyle(primary.opacity(0.7))
                                         .transition(.opacity)
                                 }
-                                Slider(value: $bitrate, in: 64...320, step: 1)
-                                    .tint(accent.color)
+                                Slider(
+                                    value: $bitrate,
+                                    in: 64...320,
+                                    step: 1,
+                                    onEditingChanged: { editing in
+                                        if editing {
+                                            userHasAdjustedBitrate = true
+                                        }
+                                    }
+                                )
+                                .tint(accent.color)
+                                .disabled(selectedFormat == .wav)
+                                .opacity(selectedFormat == .wav ? 0.5 : 1)
+                                if selectedFormat == .wav {
+                                    Text("WAV exports use lossless quality and ignore bitrate settings.")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(primary.opacity(0.65))
+                                }
                             }
                             .padding(.vertical, 14)
                             .padding(.horizontal, 18)
@@ -238,14 +271,94 @@ struct ConversionSettingsView: View {
         return "—"
     }
 
-    private func estimatedExportSizeString() -> String {
-        // Very rough estimate: duration (seconds) * bitrate (kbps) * 125 = bytes
-        let asset = AVAsset(url: videoURL)
-        let duration = CMTimeGetSeconds(asset.duration)
-        guard duration.isFinite else { return "—" }
-        let bitsPerSecond = bitrate * 1000
-        let bytes = duration * bitsPerSecond / 8
-        return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    private var estimatedSizeText: String {
+        if isLoadingAudioProperties {
+            return "Calculating…"
+        }
+        guard let bytes = estimatedExportSizeBytes() else { return "—" }
+        let clampedBytes = max(bytes, 0)
+        return ByteCountFormatter.string(fromByteCount: Int64(clampedBytes.rounded()), countStyle: .file)
+    }
+
+    private func estimatedExportSizeBytes() -> Double? {
+        if let props = audioProperties {
+            let duration = props.duration
+            guard duration.isFinite, duration > 0 else { return nil }
+            switch selectedFormat {
+            case .mp3:
+                let bitsPerSecond = Double(max(64, min(320, Int(bitrate)))) * 1000
+                return duration * bitsPerSecond / 8
+            case .m4a:
+                let chosenBitrate = Double(max(64, min(320, Int(bitrate))))
+                return duration * chosenBitrate * 1000 / 8
+            case .wav:
+                let bitsPerChannel = props.bitsPerChannel > 0 ? Double(props.bitsPerChannel) : 16
+                let sampleRate = props.sampleRate > 0 ? props.sampleRate : 44_100
+                return duration * sampleRate * Double(max(props.channels, 1)) * bitsPerChannel / 8
+            }
+        } else {
+            let asset = AVAsset(url: videoURL)
+            let duration = CMTimeGetSeconds(asset.duration)
+            guard duration.isFinite, duration > 0 else { return nil }
+            let bitsPerSecond = Double(bitrate) * 1000
+            return duration * bitsPerSecond / 8
+        }
+    }
+
+    private func ensureAudioPropertiesLoaded() {
+        guard !isLoadingAudioProperties, audioProperties == nil else { return }
+        isLoadingAudioProperties = true
+        Task {
+            let asset = AVURLAsset(url: videoURL)
+            do {
+                let durationTime = try await asset.load(.duration)
+                let duration = durationTime.seconds
+                let tracks = try await asset.loadTracks(withMediaType: .audio)
+
+                var sampleRate = 44_100.0
+                var channels = 2
+                var bitsPerChannel = 16
+                var estimatedBitrate: Double?
+
+                if let track = tracks.first {
+                    estimatedBitrate = try await track.load(.estimatedDataRate)
+                    let descriptions = try await track.load(.formatDescriptions)
+                    if let description = descriptions.first,
+                       let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(description)?.pointee {
+                        if asbd.mSampleRate > 0 { sampleRate = asbd.mSampleRate }
+                        if asbd.mChannelsPerFrame > 0 { channels = Int(asbd.mChannelsPerFrame) }
+                        if asbd.mBitsPerChannel > 0 { bitsPerChannel = Int(asbd.mBitsPerChannel) }
+                    }
+                }
+
+                await MainActor.run {
+                    audioProperties = AudioProperties(
+                        duration: duration.isFinite ? duration : 0,
+                        sampleRate: sampleRate,
+                        channels: channels,
+                        bitsPerChannel: bitsPerChannel,
+                        estimatedBitrate: estimatedBitrate
+                    )
+
+                    if !userHasAdjustedBitrate,
+                       !hasLoadedDefaultBitrate,
+                       let estimatedBitrate = estimatedBitrate,
+                       estimatedBitrate > 0 {
+                        let kbps = min(max(estimatedBitrate / 1000, 64), 320)
+                        bitrate = kbps
+                    }
+
+                    hasLoadedDefaultBitrate = true
+                    isLoadingAudioProperties = false
+                }
+            } catch {
+                await MainActor.run {
+                    audioProperties = nil
+                    hasLoadedDefaultBitrate = true
+                    isLoadingAudioProperties = false
+                }
+            }
+        }
     }
 
     private var previewSection: some View {
@@ -313,14 +426,52 @@ struct ConversionSettingsView: View {
         .frame(width: width, height: height)
     }
 
+    private var actionButtons: some View {
+        GeometryReader { geometry in
+            let spacing: CGFloat = 12
+            let totalWidth = geometry.size.width
+            let cancelWidth = max((totalWidth - spacing) * 0.25, 0)
+            let exportWidth = max((totalWidth - spacing) * 0.75, 0)
+
+            HStack(spacing: spacing) {
+                cancelButton
+                    .frame(width: cancelWidth)
+                exportButton
+                    .frame(width: exportWidth)
+            }
+            .frame(width: totalWidth, alignment: .center)
+        }
+        .frame(height: 52)
+    }
+
+    private var cancelButton: some View {
+        Button(action: cancel) {
+            HStack {
+                Spacer(minLength: 0)
+                Text("Cancel")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundColor(primary)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 14)
+            .background(primary.opacity(0.08))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(primary.opacity(0.15), lineWidth: 1)
+            )
+        }
+        .opacity(isProcessing ? 0.85 : 1)
+    }
+
     private var exportButton: some View {
         Button(action: convert) {
             HStack {
-                Spacer()
+                Spacer(minLength: 0)
                 Text(isProcessing ? "Exporting…" : "Export")
                     .font(.system(size: 18, weight: .semibold, design: .rounded))
                     .foregroundColor(background)
-                Spacer()
+                Spacer(minLength: 0)
             }
             .padding(.vertical, 14)
             .background(accent.color.opacity(isProcessing ? 0.6 : 1))
@@ -329,7 +480,6 @@ struct ConversionSettingsView: View {
         }
         .disabled(isProcessing)
         .opacity(isProcessing ? 0.9 : 1)
-        .frame(maxWidth: .infinity)
     }
 
     private var progressIndicator: some View {
@@ -343,15 +493,27 @@ struct ConversionSettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private func cancel() {
+        HapticsManager.shared.selection()
+        didCancelConversion = true
+        isProcessing = false
+        showSuccessSheet = false
+        exportURL = nil
+        dismiss()
+    }
+
     private func convert() {
         guard !isProcessing else { return }
         HapticsManager.shared.pulse()
         exportURL = nil
         progressValue = 0
         isProcessing = true
+        didCancelConversion = false
+        showSuccessSheet = false
         VideoToAudioConverter.convert(
             videoURL: videoURL,
             format: selectedFormat,
+            bitrate: Int(bitrate),
             progress: { value in
                 DispatchQueue.main.async {
                     withAnimation(.easeInOut(duration: 0.15)) {
@@ -363,14 +525,24 @@ struct ConversionSettingsView: View {
                 isProcessing = false
                 switch result {
                 case .success(let url):
+                    guard !didCancelConversion else { return }
                     exportURL = url
-                    showExporter = true
+                    HapticsManager.shared.notify(.success)
+                    showSuccessSheet = true
                 case .failure:
                     dismiss()
                 }
             }
         )
     }
+}
+
+private struct AudioProperties {
+    let duration: Double
+    let sampleRate: Double
+    let channels: Int
+    let bitsPerChannel: Int
+    let estimatedBitrate: Double?
 }
 
 private struct VideoPreviewCard: View {
@@ -758,6 +930,129 @@ struct ExportPicker: UIViewControllerRepresentable {
         UIDocumentPickerViewController(forExporting: [url])
     }
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+}
+
+struct ConversionSuccessSheet: View {
+    let url: URL
+    let accentColor: Color
+    let primaryColor: Color
+    let backgroundColor: Color
+    let onDone: () -> Void
+
+    @State private var animateCheckmark = false
+    @State private var showExporter = false
+    @State private var showShareSheet = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            HStack {
+                Text("Converted!")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundStyle(primaryColor)
+                Spacer()
+                Button(action: {
+                    HapticsManager.shared.selection()
+                    onDone()
+                }) {
+                    Text("Done")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                }
+                .foregroundStyle(accentColor)
+            }
+            .padding(.top, 4)
+
+            VStack(spacing: 18) {
+                ZStack {
+                    Circle()
+                        .fill(Color.green.opacity(0.18))
+                        .frame(width: 140, height: 140)
+                        .scaleEffect(animateCheckmark ? 1 : 0.6)
+                        .opacity(animateCheckmark ? 1 : 0)
+                    Circle()
+                        .stroke(Color.green.opacity(0.3), lineWidth: 4)
+                        .frame(width: 140, height: 140)
+                        .scaleEffect(animateCheckmark ? 1.1 : 0.7)
+                        .opacity(animateCheckmark ? 1 : 0)
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 100, weight: .bold, design: .rounded))
+                        .foregroundStyle(Color.green)
+                        .scaleEffect(animateCheckmark ? 1 : 0.6)
+                        .rotationEffect(.degrees(animateCheckmark ? 0 : -14))
+                        .opacity(animateCheckmark ? 1 : 0)
+                }
+                .frame(height: 150)
+                .animation(.spring(response: 0.7, dampingFraction: 0.75, blendDuration: 0.35), value: animateCheckmark)
+
+                Text("Successfully converted")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primaryColor.opacity(0.9))
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 12) {
+                Button(action: {
+                    HapticsManager.shared.pulse()
+                    showExporter = true
+                }) {
+                    Label("Save to Files", systemImage: "square.and.arrow.down")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(accentColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .shadow(color: accentColor.opacity(0.3), radius: 12, x: 0, y: 6)
+                }
+
+                Button(action: {
+                    HapticsManager.shared.selection()
+                    showShareSheet = true
+                }) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .foregroundColor(primaryColor)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(primaryColor.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 18)
+        .padding(.bottom, 32)
+        .frame(maxWidth: .infinity, alignment: .top)
+        .background(backgroundColor.opacity(0.98).ignoresSafeArea())
+        .onAppear {
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.7, blendDuration: 0.3)) {
+                animateCheckmark = true
+            }
+        }
+        .sheet(isPresented: $showExporter) {
+            ExportPicker(url: url)
+        }
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(items: [url])
+        }
+    }
+}
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        if let popover = controller.popoverPresentationController {
+            popover.sourceView = controller.view
+            popover.sourceRect = controller.view.bounds
+            popover.permittedArrowDirections = []
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 private struct AccessibilityHintIfNeeded: ViewModifier {

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -17,6 +17,21 @@ struct SettingsView: View {
     private var accent: AccentColorOption {
         AccentColorOption(rawValue: accentRaw) ?? .purple
     }
+    private var appVersionString: String {
+        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        switch (shortVersion?.isEmpty == false, buildVersion?.isEmpty == false) {
+        case (true, true):
+            if shortVersion == buildVersion { return shortVersion! }
+            return "\(shortVersion!) (\(buildVersion!))"
+        case (true, false):
+            return shortVersion!
+        case (false, true):
+            return buildVersion!
+        default:
+            return "—"
+        }
+    }
     @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
 
@@ -189,7 +204,7 @@ struct SettingsView: View {
             HStack {
                 Text("Version")
                 Spacer()
-                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                Text(appVersionString)
             }
             .foregroundStyle(primary.opacity(0.8))
 


### PR DESCRIPTION
## Summary
- align Info.plist metadata with build settings and surface the marketing/build version in Settings
- refine the conversion settings UI with a cancel action, better size estimates, and a post-export success sheet
- propagate bitrate selection into the export pipeline by rewriting M4A encoding and tightening the MP3 converter

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdbde6ae1c83208efbb357937846b1