### PR TITLE
Improve conversion flow and bitrate handling

### DIFF
--- a/Resonans/VideoToAudioConverter.swift
+++ b/Resonans/VideoToAudioConverter.swift
@@ -20,6 +20,7 @@ final class VideoToAudioConverter {
     static func convert(
         videoURL: URL,
         format: AudioFormat,
+        bitrate: Int,
         progress: @escaping (Double) -> Void,
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
@@ -30,7 +31,7 @@ final class VideoToAudioConverter {
         switch format {
         case .m4a:
             let out = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
-            export(asset: asset, outputURL: out, fileType: .m4a, progress: progress, completion: completion)
+            exportToM4A(asset: asset, outputURL: out, bitrate: bitrate, progress: progress, completion: completion)
         case .wav:
             let out = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
             exportToWAV(asset: asset, outputURL: out, progress: progress, completion: completion)
@@ -47,7 +48,7 @@ final class VideoToAudioConverter {
                 case .success:
                     do {
                         let mp3URL = tmp.appendingPathComponent(baseName).appendingPathExtension(format.fileExtension)
-                        try wavToMp3(wavURL: wavURL, mp3URL: mp3URL) { encodeProgress in
+                        try wavToMp3(wavURL: wavURL, mp3URL: mp3URL, bitrate: bitrate) { encodeProgress in
                             let mapped = 0.85 + (encodeProgress * 0.15)
                             progress(min(max(mapped, 0), 1))
                         }
@@ -67,37 +68,143 @@ final class VideoToAudioConverter {
         }
     }
 
-    private static func export(
+    private static func exportToM4A(
         asset: AVAsset,
         outputURL: URL,
-        fileType: AVFileType,
+        bitrate: Int,
         progress: @escaping (Double) -> Void,
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
-        guard let exporter = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
-            completion(.failure(NSError(domain: "export", code: -1)))
+        do {
+            if FileManager.default.fileExists(atPath: outputURL.path) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+
+            guard let track = asset.tracks(withMediaType: .audio).first else {
+                DispatchQueue.main.async {
+                    completion(.failure(NSError(domain: "export", code: -3)))
+                }
+                return
+            }
+
+            Task {
+                do {
+                    let formatDescriptions: [CMFormatDescription] = try await track.load(.formatDescriptions)
+                    let cmDesc: CMFormatDescription? = formatDescriptions.first
+                    let asbd = cmDesc.flatMap { CMAudioFormatDescriptionGetStreamBasicDescription($0)?.pointee }
+                    let sampleRate = asbd?.mSampleRate ?? 44_100
+                    let channels = Int(max(asbd?.mChannelsPerFrame ?? 2, 1))
+
+                    let readerSettings: [String: Any] = [
+                        AVFormatIDKey: kAudioFormatLinearPCM,
+                        AVSampleRateKey: sampleRate,
+                        AVNumberOfChannelsKey: channels,
+                        AVLinearPCMBitDepthKey: 16,
+                        AVLinearPCMIsBigEndianKey: false,
+                        AVLinearPCMIsFloatKey: false,
+                        AVLinearPCMIsNonInterleaved: false
+                    ]
+
+                    let writerSettings: [String: Any] = [
+                        AVFormatIDKey: kAudioFormatMPEG4AAC,
+                        AVEncoderBitRateKey: max(bitrate, 64) * 1000,
+                        AVSampleRateKey: sampleRate,
+                        AVNumberOfChannelsKey: channels,
+                        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+                    ]
+
+                    let reader = try AVAssetReader(asset: asset)
+                    let readerOutput = AVAssetReaderTrackOutput(track: track, outputSettings: readerSettings)
+                    readerOutput.alwaysCopiesSampleData = false
+                    guard reader.canAdd(readerOutput) else {
+                        DispatchQueue.main.async {
+                            completion(.failure(NSError(domain: "export", code: -10)))
+                        }
+                        return
+                    }
+                    reader.add(readerOutput)
+
+                    let writer = try AVAssetWriter(outputURL: outputURL, fileType: .m4a)
+                    let writerInput = AVAssetWriterInput(mediaType: .audio, outputSettings: writerSettings)
+                    writerInput.expectsMediaDataInRealTime = false
+                    guard writer.canAdd(writerInput) else {
+                        DispatchQueue.main.async {
+                            completion(.failure(NSError(domain: "export", code: -11)))
+                        }
+                        return
+                    }
+                    writer.add(writerInput)
+
+                    guard writer.startWriting() else {
+                        throw writer.error ?? NSError(domain: "export", code: -12)
+                    }
+
+                    reader.startReading()
+                    writer.startSession(atSourceTime: .zero)
+
+                    let durationSeconds = asset.duration.seconds
+                    let queue = DispatchQueue(label: "m4a.export.queue")
+                    writerInput.requestMediaDataWhenReady(on: queue) {
+                        while writerInput.isReadyForMoreMediaData {
+                            if reader.status == .reading, let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+                                if !writerInput.append(sampleBuffer) {
+                                    reader.cancelReading()
+                                    writerInput.markAsFinished()
+                                    writer.cancelWriting()
+                                    let error = writer.error ?? NSError(domain: "export", code: -13)
+                                    DispatchQueue.main.async {
+                                        completion(.failure(error))
+                                    }
+                                    return
+                                }
+
+                                if durationSeconds.isFinite && durationSeconds > 0 {
+                                    let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+                                    let ratio = min(max(time / durationSeconds, 0), 1)
+                                    DispatchQueue.main.async {
+                                        progress(ratio)
+                                    }
+                                }
+                            } else {
+                                writerInput.markAsFinished()
+                                switch reader.status {
+                                case .completed:
+                                    writer.finishWriting {
+                                        if let error = writer.error {
+                                            DispatchQueue.main.async {
+                                                completion(.failure(error))
+                                            }
+                                        } else {
+                                            DispatchQueue.main.async {
+                                                progress(1)
+                                                completion(.success(outputURL))
+                                            }
+                                        }
+                                    }
+                                case .failed, .cancelled:
+                                    let error = reader.error ?? writer.error ?? NSError(domain: "export", code: -14)
+                                    writer.cancelWriting()
+                                    DispatchQueue.main.async {
+                                        completion(.failure(error))
+                                    }
+                                default:
+                                    break
+                                }
+                                return
+                            }
+                        }
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
+                }
+            }
+
             return
-        }
-        if FileManager.default.fileExists(atPath: outputURL.path) {
-            try? FileManager.default.removeItem(at: outputURL)
-        }
-        exporter.outputURL = outputURL
-        exporter.outputFileType = fileType
-        let watcher = ExportProgressWatcher(exporter: exporter, progress: progress)
-        exporter.exportAsynchronously {
-            watcher.invalidate()
-            switch exporter.status {
-            case .completed:
-                DispatchQueue.main.async {
-                    progress(1)
-                    completion(.success(outputURL))
-                }
-            case .failed, .cancelled:
-                DispatchQueue.main.async {
-                    completion(.failure(exporter.error ?? NSError(domain: "export", code: -2)))
-                }
-            default:
-                break
+        } catch {
+            DispatchQueue.main.async {
+                completion(.failure(error))
             }
         }
     }
@@ -236,20 +343,34 @@ final class VideoToAudioConverter {
         }
     }
 
-    private static func wavToMp3(wavURL: URL, mp3URL: URL, progress: @escaping (Double) -> Void) throws {
+    private static func wavToMp3(wavURL: URL, mp3URL: URL, bitrate: Int, progress: @escaping (Double) -> Void) throws {
         guard let pcm = fopen(wavURL.path, "rb") else { throw NSError(domain: "lame", code: -1) }
         defer { fclose(pcm) }
         guard let mp3 = fopen(mp3URL.path, "wb") else { throw NSError(domain: "lame", code: -2) }
         defer { fclose(mp3) }
         guard let lame: OpaquePointer = lame_init() else { throw NSError(domain: "lame", code: -3) }
-        lame_set_in_samplerate(lame, 44100)
-        lame_set_VBR(lame, vbr_default)
+        var header = [UInt8](repeating: 0, count: 44)
+        fread(&header, 1, header.count, pcm)
+        let sampleRate = header.withUnsafeBytes { ptr -> UInt32 in
+            ptr.load(fromByteOffset: 24, as: UInt32.self).littleEndian
+        }
+        let channels = header.withUnsafeBytes { ptr -> UInt16 in
+            ptr.load(fromByteOffset: 22, as: UInt16.self).littleEndian
+        }
+        let resolvedSampleRate = sampleRate > 0 ? Int32(sampleRate) : 44_100
+        let resolvedChannels = max(Int32(channels), 1)
+        lame_set_in_samplerate(lame, resolvedSampleRate)
+        lame_set_num_channels(lame, resolvedChannels)
+        lame_set_VBR(lame, vbr_off)
+        lame_set_brate(lame, Int32(max(bitrate, 64)))
+        lame_set_quality(lame, 2)
         lame_init_params(lame)
+        fseek(pcm, 44, SEEK_SET)
         let pcmBufferSize: Int32 = 8192
         var pcmBuffer = [Int16](repeating: 0, count: Int(pcmBufferSize))
         var mp3Buffer = [UInt8](repeating: 0, count: Int(8192))
         var read: Int32
-        let totalBytes = (try? FileManager.default.attributesOfItem(atPath: wavURL.path)[.size] as? NSNumber)?.doubleValue ?? 0
+        let totalBytes = max(((try? FileManager.default.attributesOfItem(atPath: wavURL.path)[.size] as? NSNumber)?.doubleValue ?? 0) - 44, 0)
         var processedBytes: Double = 0
         repeat {
             read = Int32(pcmBuffer.withUnsafeMutableBufferPointer { ptr in
@@ -275,31 +396,7 @@ final class VideoToAudioConverter {
             progress(1)
         }
         lame_close(lame)
-    }
-}
-
-private final class ExportProgressWatcher {
-    private var timer: DispatchSourceTimer?
-    private weak var exporter: AVAssetExportSession?
-
-    init(exporter: AVAssetExportSession, progress: @escaping (Double) -> Void) {
-        self.exporter = exporter
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
-        timer.schedule(deadline: .now(), repeating: .milliseconds(120))
-        timer.setEventHandler { [weak exporter] in
-            guard let exporter = exporter else { return }
-            let value = min(max(Double(exporter.progress), 0), 1)
-            DispatchQueue.main.async {
-                progress(value)
-            }
-        }
-        timer.resume()
-        self.timer = timer
-    }
-
-    func invalidate() {
-        timer?.cancel()
-        timer = nil
+        try? FileManager.default.removeItem(at: wavURL)
     }
 }
 

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -22,6 +22,18 @@ struct SettingsView: View {
 
     private var primary: Color { colorScheme == .dark ? .white : .black }
 
+    private var versionDisplayString: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        if let version = version, !version.isEmpty {
+            if let build = build, !build.isEmpty {
+                return "\(version) (\(build))"
+            }
+            return version
+        }
+        return "—"
+    }
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -189,7 +201,7 @@ struct SettingsView: View {
             HStack {
                 Text("Version")
                 Spacer()
-                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                Text(versionDisplayString)
             }
             .foregroundStyle(primary.opacity(0.8))
 


### PR DESCRIPTION
## Summary
- add a success sheet with save/share actions, adjust the conversion footer to include a cancel button, and improve estimated size calculations
- apply the bitrate slider to the export pipeline by customising AAC/MP3 outputs and cleaning up temporary files
- surface the marketing version and build number together in Settings

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cdbde6ae1c83208efbb357937846b1