### PR TITLE
Refine shared styling and unify shadows

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -26,7 +26,7 @@ struct BottomSheetGallery: View {
                             .foregroundStyle(primary.opacity(0.85))
                             .padding(.leading, 6)
                             .padding(.bottom, 4)
-                            .shadow(color: (colorScheme == .light ? Color.white : Color.black).opacity(0.9), radius: 4, x: 0, y: -1)
+                            .appShadow(.text, colorScheme: colorScheme)
                     ) {
                         LazyVGrid(columns: columns, spacing: 16) {
                             ForEach(items, id: \.localIdentifier) { asset in
@@ -155,6 +155,7 @@ struct BottomSheetGallery: View {
                     }
                 }
             }
+            .appShadow(.low, colorScheme: colorScheme)
             .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
             .scaleEffect(hasAppeared ? 1 : 0.8)
             .onTapGesture {

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -4,19 +4,15 @@ struct RecentRow: View {
     let item: RecentItem
 
     @Environment(\.colorScheme) private var colorScheme
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var primary: Color { AppColor.primary(for: colorScheme) }
 
     var body: some View {
         HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(primary.opacity(0.14))
+            Image(systemName: "waveform")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(primary.opacity(0.9))
                 .frame(width: 56, height: 56)
-                .overlay(
-                    Image(systemName: "waveform")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(primary.opacity(0.9))
-                )
-                .shadow(color: .black.opacity(0.45), radius: 12, x: 0, y: 6)
+                .appIconBackground(primary: primary, colorScheme: colorScheme, cornerRadius: 14)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
@@ -42,16 +38,7 @@ struct RecentRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(primary.opacity(0.16))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
-        )
-        .shadow(color: .black.opacity(0.55), radius: 18, x: 0, y: 10)
-        .shadow(color: colorScheme == .dark ? Color.white.opacity(0.06) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
+        .appCardBackground(primary: primary, colorScheme: colorScheme, cornerRadius: 22, elevation: .medium)
     }
 }
 

--- a/Resonans/StyleConstants.swift
+++ b/Resonans/StyleConstants.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Global layout constants that are shared across views.
 enum AppStyle {
     /// Standard corner radius used throughout the app
     static let cornerRadius: CGFloat = 28
@@ -7,4 +8,182 @@ enum AppStyle {
     static let horizontalPadding: CGFloat = 22
     /// Internal padding within boxed views
     static let innerPadding: CGFloat = 20
+}
+
+/// Surface styling related values.
+enum AppSurface {
+    /// Background fill opacity used for cards and grouped boxes.
+    static let cardFillOpacity: Double = 0.09
+    /// Border opacity for card outlines.
+    static let cardStrokeOpacity: Double = 0.12
+    /// Background opacity for small icon containers.
+    static let iconFillOpacity: Double = 0.16
+}
+
+/// App-wide color helpers to keep color usage consistent.
+enum AppColor {
+    static func background(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .black : .white
+    }
+
+    static func primary(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    static func elevatedBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color(white: 0.1) : Color(white: 0.92)
+    }
+}
+
+/// Discrete elevation levels for the app that describe the drop shadow to apply.
+enum AppElevation {
+    case text
+    case low
+    case medium
+    case high
+
+    var radius: CGFloat {
+        switch self {
+        case .text: return 4
+        case .low: return 12
+        case .medium: return 18
+        case .high: return 26
+        }
+    }
+
+    var yOffset: CGFloat {
+        switch self {
+        case .text: return 1
+        case .low: return 6
+        case .medium: return 10
+        case .high: return 20
+        }
+    }
+
+    var baseOpacity: Double {
+        switch self {
+        case .text: return 0.28
+        case .low: return 0.35
+        case .medium: return 0.45
+        case .high: return 0.5
+        }
+    }
+
+    var highlightOpacityLight: Double {
+        switch self {
+        case .text: return 0.18
+        case .low: return 0.22
+        case .medium: return 0.25
+        case .high: return 0.28
+        }
+    }
+
+    var highlightOpacityDark: Double {
+        switch self {
+        case .text: return 0.08
+        case .low: return 0.08
+        case .medium: return 0.1
+        case .high: return 0.12
+        }
+    }
+}
+
+private struct AppShadowModifier: ViewModifier {
+    let elevation: AppElevation
+    let colorScheme: ColorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .shadow(
+                color: Color.black.opacity(elevation.baseOpacity),
+                radius: elevation.radius,
+                x: 0,
+                y: elevation.yOffset
+            )
+            .shadow(
+                color: Color.white.opacity(
+                    colorScheme == .dark ? elevation.highlightOpacityDark : elevation.highlightOpacityLight
+                ),
+                radius: 1,
+                x: 0,
+                y: 1
+            )
+    }
+}
+
+private struct AppCardBackgroundModifier: ViewModifier {
+    let primary: Color
+    let colorScheme: ColorScheme
+    let cornerRadius: CGFloat
+    let elevation: AppElevation
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(primary.opacity(AppSurface.cardFillOpacity))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .stroke(primary.opacity(AppSurface.cardStrokeOpacity), lineWidth: 1)
+                    )
+            )
+            .appShadow(elevation, colorScheme: colorScheme)
+    }
+}
+
+private struct AppIconBackgroundModifier: ViewModifier {
+    let primary: Color
+    let colorScheme: ColorScheme
+    let cornerRadius: CGFloat
+    let elevation: AppElevation
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(primary.opacity(AppSurface.iconFillOpacity))
+            )
+            .appShadow(elevation, colorScheme: colorScheme)
+    }
+}
+
+extension View {
+    /// Applies a consistent app shadow for the provided elevation level.
+    func appShadow(_ elevation: AppElevation = .medium, colorScheme: ColorScheme) -> some View {
+        modifier(AppShadowModifier(elevation: elevation, colorScheme: colorScheme))
+    }
+
+    /// Applies the common card styling (background, border, shadow).
+    func appCardBackground(
+        primary: Color,
+        colorScheme: ColorScheme,
+        cornerRadius: CGFloat = AppStyle.cornerRadius,
+        elevation: AppElevation = .medium
+    ) -> some View {
+        modifier(
+            AppCardBackgroundModifier(
+                primary: primary,
+                colorScheme: colorScheme,
+                cornerRadius: cornerRadius,
+                elevation: elevation
+            )
+        )
+    }
+
+    /// Applies the styling used for small icon containers.
+    func appIconBackground(
+        primary: Color,
+        colorScheme: ColorScheme,
+        cornerRadius: CGFloat = 14,
+        elevation: AppElevation = .low
+    ) -> some View {
+        modifier(
+            AppIconBackgroundModifier(
+                primary: primary,
+                colorScheme: colorScheme,
+                cornerRadius: cornerRadius,
+                elevation: elevation
+            )
+        )
+    }
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -39,10 +39,8 @@ struct ContentView: View {
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { colorScheme == .dark ? .black : .white }
-    private var primary: Color { colorScheme == .dark ? .white : .black }
-    /// Uses white shadows in light mode and black shadows in dark mode
-    private var shadowColor: Color { colorScheme == .light ? .white : .black }
+    private var background: Color { AppColor.background(for: colorScheme) }
+    private var primary: Color { AppColor.primary(for: colorScheme) }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -389,7 +387,7 @@ struct ContentView: View {
             .tracking(0.5)
             .foregroundStyle(primary)
             .padding(.leading, 22)
-            .shadow(color: shadowColor.opacity(0.8), radius: 4, x: 0, y: 1)
+            .appShadow(.text, colorScheme: colorScheme)
             .animation(.easeInOut(duration: 0.25), value: selectedTab)
             Spacer()
             Button(action: {
@@ -399,7 +397,7 @@ struct ContentView: View {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(primary)
-                    .shadow(color: shadowColor.opacity(0.8), radius: 4, x: 0, y: 1)
+                    .appShadow(.text, colorScheme: colorScheme)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 22)
@@ -423,7 +421,7 @@ struct ContentView: View {
                 // Large rectangle (plus)
                 ZStack {
                     RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
+                        .fill(primary.opacity(AppSurface.cardFillOpacity))
                         .overlay(
                             VStack(spacing: 14) {
                                 Image(systemName: "plus")
@@ -437,11 +435,10 @@ struct ContentView: View {
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(AppSurface.cardStrokeOpacity), lineWidth: 1)
                         )
                         .frame(width: fullWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+                        .appShadow(.high, colorScheme: colorScheme)
                         .onTapGesture {
                             HapticsManager.shared.pulse()
                             withAnimation(.easeInOut(duration: 0.35)) {
@@ -459,7 +456,7 @@ struct ContentView: View {
                 HStack(spacing: 16) {
                     // Files rectangle
                     RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
+                        .fill(primary.opacity(AppSurface.cardFillOpacity))
                         .overlay(
                             VStack(spacing: 8) {
                                 Image(systemName: "doc.fill")
@@ -472,11 +469,10 @@ struct ContentView: View {
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(AppSurface.cardStrokeOpacity), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+                        .appShadow(.medium, colorScheme: colorScheme)
                         .onTapGesture {
                             HapticsManager.shared.pulse()
                             showFilePicker = true
@@ -486,7 +482,7 @@ struct ContentView: View {
                         }
                     // Gallery rectangle
                     RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
+                        .fill(primary.opacity(AppSurface.cardFillOpacity))
                         .overlay(
                             VStack(spacing: 8) {
                                 Image(systemName: "photo.on.rectangle.angled")
@@ -499,11 +495,10 @@ struct ContentView: View {
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
+                                .strokeBorder(primary.opacity(AppSurface.cardStrokeOpacity), lineWidth: 1)
                         )
                         .frame(width: targetWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+                        .appShadow(.medium, colorScheme: colorScheme)
                         .onTapGesture {
                             HapticsManager.shared.pulse()
                             selectedTab = 1
@@ -574,16 +569,7 @@ struct ContentView: View {
             .padding(.bottom, 14)
             .frame(height: showAllRecents ? nil : 323)
         }
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(0.07))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
-                .shadow(color: shadowColor.opacity(0.55), radius: 22, x: 0, y: 14)
-                .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
-        )
+        .appCardBackground(primary: primary, colorScheme: colorScheme, elevation: .medium)
         .padding(.horizontal, AppStyle.horizontalPadding)
         .padding(.bottom, 120)
     }

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -10,9 +10,8 @@ struct ConversionSettingsView: View {
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { colorScheme == .dark ? .black : .white }
-    private var adaptiveBackground: Color { colorScheme == .dark ? Color(white: 0.1) : Color(white: 0.9) }
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var background: Color { AppColor.background(for: colorScheme) }
+    private var primary: Color { AppColor.primary(for: colorScheme) }
 
     @State private var selectedFormat: AudioFormat = .mp3
     @State private var isProcessing = false
@@ -145,62 +144,48 @@ struct ConversionSettingsView: View {
     private var settingsSection: some View {
         VStack(alignment: .leading, spacing: 18) {
             // File Size
-            ZStack {
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primary.opacity(0.09))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                    )
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("File Size")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                    HStack(spacing: 16) {
-                        Text("Original: \(fileSizeString(for: videoURL))")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                        Text("Estimated: \(estimatedExportSizeString())")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                    }
-                }
-                .padding(.vertical, 14)
-                .padding(.horizontal, 18)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-
-            // Export Format
-            ZStack {
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primary.opacity(0.09))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                    )
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Format")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                    Text("Original: \(originalFormatLabel)")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("File Size")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                HStack(spacing: 16) {
+                    Text("Original: \(fileSizeString(for: videoURL))")
                         .font(.system(size: 14))
                         .foregroundStyle(primary.opacity(0.8))
-                    HStack {
-                        Text("When Exported:")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                        Picker("", selection: $selectedFormat) {
-                            Text("mp3").tag(AudioFormat.mp3)
-                            Text("wav").tag(AudioFormat.wav)
-                            Text("m4a").tag(AudioFormat.m4a)
-                        }
-                        .pickerStyle(.menu)
-                    }
+                    Text("Estimated: \(estimatedExportSizeString())")
+                        .font(.system(size: 14))
+                        .foregroundStyle(primary.opacity(0.8))
                 }
-                .padding(.vertical, 14)
-                .padding(.horizontal, 18)
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .padding(.vertical, 14)
+            .padding(.horizontal, 18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .appCardBackground(primary: primary, colorScheme: colorScheme, elevation: .medium)
+
+            // Export Format
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Format")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text("Original: \(originalFormatLabel)")
+                    .font(.system(size: 14))
+                    .foregroundStyle(primary.opacity(0.8))
+                HStack {
+                    Text("When Exported:")
+                        .font(.system(size: 14))
+                        .foregroundStyle(primary.opacity(0.8))
+                    Picker("", selection: $selectedFormat) {
+                        Text("mp3").tag(AudioFormat.mp3)
+                        Text("wav").tag(AudioFormat.wav)
+                        Text("m4a").tag(AudioFormat.m4a)
+                    }
+                    .pickerStyle(.menu)
+                }
+            }
+            .padding(.vertical, 14)
+            .padding(.horizontal, 18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .appCardBackground(primary: primary, colorScheme: colorScheme, elevation: .medium)
 
             // More… button
             if !showAdvanced {
@@ -228,50 +213,43 @@ struct ConversionSettingsView: View {
                 if showAdvanced {
                     VStack(spacing: 18) {
                         // Bitrate setting
-                        ZStack {
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .fill(primary.opacity(0.09))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                                )
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text("Bitrate")
-                                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                        .foregroundStyle(primary)
-                                    Spacer()
-                                    Text(bitrateLabel)
-                                        .font(.system(size: 14))
-                                        .foregroundStyle(primary.opacity(0.8))
-                                    Button(action: {
-                                        withAnimation { showBitrateInfo.toggle() }
-                                    }) {
-                                        Image(systemName: "questionmark.circle")
-                                            .opacity(0.5)
-                                    }
-                                    .buttonStyle(.plain)
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Bitrate")
+                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(primary)
+                                Spacer()
+                                Text(bitrateLabel)
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(primary.opacity(0.8))
+                                Button(action: {
+                                    withAnimation { showBitrateInfo.toggle() }
+                                }) {
+                                    Image(systemName: "questionmark.circle")
+                                        .opacity(0.5)
                                 }
-                                if showBitrateInfo {
-                                    Text("Bitrate controls audio quality and file size.")
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(primary.opacity(0.7))
-                                        .transition(.opacity)
-                                }
-                                if selectedFormat == .wav {
-                                    Text("WAV exports keep the original quality (~\(wavBitrateKbps) kbps).")
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(primary.opacity(0.7))
-                                        .transition(.opacity)
-                                } else {
-                                    Slider(value: $bitrate, in: 64...320, step: 1)
-                                        .tint(accent.color)
-                                }
+                                .buttonStyle(.plain)
                             }
-                            .padding(.vertical, 14)
-                            .padding(.horizontal, 18)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            if showBitrateInfo {
+                                Text("Bitrate controls audio quality and file size.")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(primary.opacity(0.7))
+                                    .transition(.opacity)
+                            }
+                            if selectedFormat == .wav {
+                                Text("WAV exports keep the original quality (~\(wavBitrateKbps) kbps).")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(primary.opacity(0.7))
+                                    .transition(.opacity)
+                            } else {
+                                Slider(value: $bitrate, in: 64...320, step: 1)
+                                    .tint(accent.color)
+                            }
                         }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 18)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .appCardBackground(primary: primary, colorScheme: colorScheme, elevation: .medium)
                         // Add more advanced settings here as needed
 
                         Button(action: {
@@ -418,7 +396,7 @@ struct ConversionSettingsView: View {
             .padding(.vertical, 14)
             .background(accent.color.opacity(isProcessing ? 0.6 : 1))
             .clipShape(Capsule())
-            .shadow(color: accent.color.opacity(0.35), radius: 14, x: 0, y: 8)
+            .appShadow(.medium, colorScheme: colorScheme)
         }
         .disabled(isProcessing)
         .opacity(isProcessing ? 0.9 : 1)
@@ -646,7 +624,7 @@ private struct ConversionSuccessSheet: View {
                 })
             }
             .padding(.horizontal, AppStyle.horizontalPadding)
-            .shadow(color: accentColor.opacity(0.35), radius: 14, x: 0, y: 8)
+            .appShadow(.medium, colorScheme: colorScheme)
             .padding(.bottom, 30)
         }
         .background(LinearGradient(

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
 
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var primary: Color { AppColor.primary(for: colorScheme) }
 
     private var versionDisplayString: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
@@ -255,16 +255,7 @@ struct SettingsView: View {
         }
         .padding(AppStyle.innerPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(0.07))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
-                .shadow(color: colorScheme == .dark ? Color.white.opacity(0.05) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
-        )
+        .appCardBackground(primary: primary, colorScheme: colorScheme, elevation: .medium)
         .padding(.horizontal, AppStyle.horizontalPadding)
     }
 }


### PR DESCRIPTION
## Summary
- add centralized color, surface, and shadow helpers to StyleConstants for reuse across the app
- update main views and components to consume the shared card/icon styling and consistent shadow elevations
- add shadows to gallery thumbnails and simplify repeated background setups for better visual parity

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce06bbd2288320ba54ba1d910c4124