### PR TITLE
Unify card styling and shadows across UI

### DIFF
--- a/Resonans/Components/BottomSheetGallery.swift
+++ b/Resonans/Components/BottomSheetGallery.swift
@@ -10,7 +10,7 @@ struct BottomSheetGallery: View {
 
     private let columns: [GridItem] = Array(repeating: .init(.flexible(), spacing: 16, alignment: .center), count: 3)
     @Environment(\.colorScheme) private var colorScheme
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     var body: some View {
         let grouped = Dictionary(grouping: assets) { asset in
@@ -26,7 +26,7 @@ struct BottomSheetGallery: View {
                             .foregroundStyle(primary.opacity(0.85))
                             .padding(.leading, 6)
                             .padding(.bottom, 4)
-                            .shadow(color: (colorScheme == .light ? Color.white : Color.black).opacity(0.9), radius: 4, x: 0, y: -1)
+                            .appTextShadow(colorScheme: colorScheme)
                     ) {
                         LazyVGrid(columns: columns, spacing: 16) {
                             ForEach(items, id: \.localIdentifier) { asset in
@@ -156,6 +156,7 @@ struct BottomSheetGallery: View {
                 }
             }
             .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
+            .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
             .scaleEffect(hasAppeared ? 1 : 0.8)
             .onTapGesture {
                 HapticsManager.shared.pulse()

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -4,19 +4,23 @@ struct RecentRow: View {
     let item: RecentItem
 
     @Environment(\.colorScheme) private var colorScheme
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     var body: some View {
         HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(primary.opacity(0.14))
+            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.iconFillOpacity))
                 .frame(width: 56, height: 56)
                 .overlay(
                     Image(systemName: "waveform")
                         .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(primary.opacity(0.9))
                 )
-                .shadow(color: .black.opacity(0.45), radius: 12, x: 0, y: 6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.iconStrokeOpacity), lineWidth: 1)
+                )
+                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
@@ -42,16 +46,14 @@ struct RecentRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(primary.opacity(0.16))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .appCardStyle(
+            primary: primary,
+            colorScheme: colorScheme,
+            cornerRadius: AppStyle.compactCornerRadius,
+            fillOpacity: AppStyle.compactCardFillOpacity,
+            shadowLevel: .small
         )
-        .shadow(color: .black.opacity(0.55), radius: 18, x: 0, y: 10)
-        .shadow(color: colorScheme == .dark ? Color.white.opacity(0.06) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
     }
 }
 

--- a/Resonans/StyleConstants.swift
+++ b/Resonans/StyleConstants.swift
@@ -3,8 +3,144 @@ import SwiftUI
 enum AppStyle {
     /// Standard corner radius used throughout the app
     static let cornerRadius: CGFloat = 28
+    /// Compact corner radius for smaller cards and rows
+    static let compactCornerRadius: CGFloat = 22
+    /// Corner radius for icons and thumbnails
+    static let iconCornerRadius: CGFloat = 14
+
     /// Standard horizontal padding for boxed views
     static let horizontalPadding: CGFloat = 22
     /// Internal padding within boxed views
     static let innerPadding: CGFloat = 20
+
+    /// Default opacity values for card backgrounds and strokes
+    static let cardFillOpacity: Double = 0.09
+    static let compactCardFillOpacity: Double = 0.12
+    static let subtleCardFillOpacity: Double = 0.07
+    static let iconFillOpacity: Double = 0.14
+    static let strokeOpacity: Double = 0.10
+    static let iconStrokeOpacity: Double = 0.12
+    static let textShadowOpacity: Double = 0.8
+
+    enum ShadowLevel {
+        case small
+        case medium
+        case large
+        case text
+    }
+
+    struct ShadowConfiguration {
+        let radius: CGFloat
+        let yOffset: CGFloat
+        let opacity: Double
+        let includesHighlight: Bool
+    }
+
+    static func shadowConfiguration(for level: ShadowLevel) -> ShadowConfiguration {
+        switch level {
+        case .large:
+            return .init(radius: 26, yOffset: 20, opacity: 0.6, includesHighlight: true)
+        case .medium:
+            return .init(radius: 22, yOffset: 14, opacity: 0.55, includesHighlight: true)
+        case .small:
+            return .init(radius: 18, yOffset: 10, opacity: 0.5, includesHighlight: true)
+        case .text:
+            return .init(radius: 4, yOffset: 1, opacity: textShadowOpacity, includesHighlight: false)
+        }
+    }
+
+    static func background(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .black : .white
+    }
+
+    static func primary(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    static func shadowColor(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .black : .black
+    }
+
+    static func highlightShadowColor(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.white.opacity(0.06) : Color.white.opacity(0.25)
+    }
+}
+
+private struct AppShadowModifier: ViewModifier {
+    let colorScheme: ColorScheme
+    let level: AppStyle.ShadowLevel
+    let overrideOpacity: Double?
+
+    func body(content: Content) -> some View {
+        let configuration = AppStyle.shadowConfiguration(for: level)
+        let mainOpacity = overrideOpacity ?? configuration.opacity
+        var view = content.shadow(
+            color: AppStyle.shadowColor(for: colorScheme).opacity(mainOpacity),
+            radius: configuration.radius,
+            x: 0,
+            y: configuration.yOffset
+        )
+        if configuration.includesHighlight {
+            view = view.shadow(
+                color: AppStyle.highlightShadowColor(for: colorScheme),
+                radius: 1,
+                x: 0,
+                y: 1
+            )
+        }
+        return view
+    }
+}
+
+private struct AppCardStyleModifier: ViewModifier {
+    let primary: Color
+    let colorScheme: ColorScheme
+    let cornerRadius: CGFloat
+    let fillOpacity: Double
+    let strokeOpacity: Double
+    let shadowLevel: AppStyle.ShadowLevel
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(primary.opacity(fillOpacity))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .strokeBorder(primary.opacity(strokeOpacity), lineWidth: 1)
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .modifier(AppShadowModifier(colorScheme: colorScheme, level: shadowLevel, overrideOpacity: nil))
+    }
+}
+
+extension View {
+    func appShadow(colorScheme: ColorScheme, level: AppStyle.ShadowLevel, opacity: Double? = nil) -> some View {
+        modifier(AppShadowModifier(colorScheme: colorScheme, level: level, overrideOpacity: opacity))
+    }
+
+    func appTextShadow(colorScheme: ColorScheme) -> some View {
+        appShadow(colorScheme: colorScheme, level: .text)
+    }
+
+    func appCardStyle(
+        primary: Color,
+        colorScheme: ColorScheme,
+        cornerRadius: CGFloat = AppStyle.cornerRadius,
+        fillOpacity: Double = AppStyle.cardFillOpacity,
+        strokeOpacity: Double = AppStyle.strokeOpacity,
+        shadowLevel: AppStyle.ShadowLevel = .medium
+    ) -> some View {
+        modifier(
+            AppCardStyleModifier(
+                primary: primary,
+                colorScheme: colorScheme,
+                cornerRadius: cornerRadius,
+                fillOpacity: fillOpacity,
+                strokeOpacity: strokeOpacity,
+                shadowLevel: shadowLevel
+            )
+        )
+    }
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -39,10 +39,8 @@ struct ContentView: View {
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { colorScheme == .dark ? .black : .white }
-    private var primary: Color { colorScheme == .dark ? .white : .black }
-    /// Uses white shadows in light mode and black shadows in dark mode
-    private var shadowColor: Color { colorScheme == .light ? .white : .black }
+    private var background: Color { AppStyle.background(for: colorScheme) }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -389,7 +387,7 @@ struct ContentView: View {
             .tracking(0.5)
             .foregroundStyle(primary)
             .padding(.leading, 22)
-            .shadow(color: shadowColor.opacity(0.8), radius: 4, x: 0, y: 1)
+            .appTextShadow(colorScheme: colorScheme)
             .animation(.easeInOut(duration: 0.25), value: selectedTab)
             Spacer()
             Button(action: {
@@ -399,7 +397,7 @@ struct ContentView: View {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(primary)
-                    .shadow(color: shadowColor.opacity(0.8), radius: 4, x: 0, y: 1)
+                    .appTextShadow(colorScheme: colorScheme)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 22)
@@ -420,97 +418,20 @@ struct ContentView: View {
                             }
                         }
                 }
-                // Large rectangle (plus)
-                ZStack {
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
-                        .overlay(
-                            VStack(spacing: 14) {
-                                Image(systemName: "plus")
-                                    .font(.system(size: 56, weight: .bold))
-                                    .foregroundStyle(primary)
-                                Text("Click to Extract Audio")
-                                    .font(.system(size: 24, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(primary)
-                                
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                        )
-                        .frame(width: fullWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                showSourceOptions = true
-                            }
-                        }
-                        .scaleEffect(showSourceOptions ? 0.75 : 1.0)
-                        .animation(.spring(response: 0.45, dampingFraction: 0.6, blendDuration: 0), value: showSourceOptions)
-                        .opacity(showSourceOptions ? 0.0 : 1.0)
-                        .animation(.easeInOut(duration: 0.3), value: showSourceOptions)
-                        .allowsHitTesting(!showSourceOptions)
-                        .zIndex(showSourceOptions ? 0 : 1)
-                }
-                // Two small rectangles (Files and Gallery)
+                primarySourceCard(width: fullWidth)
                 HStack(spacing: 16) {
-                    // Files rectangle
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
-                        .overlay(
-                            VStack(spacing: 8) {
-                                Image(systemName: "doc.fill")
-                                    .font(.system(size: 36, weight: .bold))
-                                    .foregroundStyle(primary)
-                                Text("Files")
-                                    .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(primary)
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                        )
-                        .frame(width: targetWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            showFilePicker = true
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                showSourceOptions = false
-                            }
+                    sourceOptionCard(icon: "doc.fill", title: "Files", width: targetWidth) {
+                        showFilePicker = true
+                        withAnimation(.easeInOut(duration: 0.35)) {
+                            showSourceOptions = false
                         }
-                    // Gallery rectangle
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(primary.opacity(0.09))
-                        .overlay(
-                            VStack(spacing: 8) {
-                                Image(systemName: "photo.on.rectangle.angled")
-                                    .font(.system(size: 36, weight: .bold))
-                                    .foregroundStyle(primary)
-                                Text("Gallery")
-                                    .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(primary)
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                        )
-                        .frame(width: targetWidth, height: 165)
-                        .shadow(color: shadowColor.opacity(0.65), radius: 26, x: 0, y: 20)
-                        .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            selectedTab = 1
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                showSourceOptions = false
-                            }
+                    }
+                    sourceOptionCard(icon: "photo.on.rectangle.angled", title: "Gallery", width: targetWidth) {
+                        selectedTab = 1
+                        withAnimation(.easeInOut(duration: 0.35)) {
+                            showSourceOptions = false
                         }
+                    }
                 }
                 .scaleEffect(showSourceOptions ? 1.0 : 0.75)
                 .animation(.spring(response: 0.45, dampingFraction: 0.6, blendDuration: 0), value: showSourceOptions)
@@ -533,6 +454,48 @@ struct ContentView: View {
             )
         }
         .frame(height: 165)
+    }
+
+    private func primarySourceCard(width: CGFloat) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: "plus")
+                .font(.system(size: 56, weight: .bold))
+                .foregroundStyle(primary)
+            Text("Click to Extract Audio")
+                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                .foregroundStyle(primary)
+        }
+        .frame(width: width, height: 165)
+        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
+        .onTapGesture {
+            HapticsManager.shared.pulse()
+            withAnimation(.easeInOut(duration: 0.35)) {
+                showSourceOptions = true
+            }
+        }
+        .scaleEffect(showSourceOptions ? 0.75 : 1.0)
+        .animation(.spring(response: 0.45, dampingFraction: 0.6, blendDuration: 0), value: showSourceOptions)
+        .opacity(showSourceOptions ? 0.0 : 1.0)
+        .animation(.easeInOut(duration: 0.3), value: showSourceOptions)
+        .allowsHitTesting(!showSourceOptions)
+        .zIndex(showSourceOptions ? 0 : 1)
+    }
+
+    private func sourceOptionCard(icon: String, title: String, width: CGFloat, action: @escaping () -> Void) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 36, weight: .bold))
+                .foregroundStyle(primary)
+            Text(title)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundStyle(primary)
+        }
+        .frame(width: width, height: 165)
+        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
+        .onTapGesture {
+            HapticsManager.shared.pulse()
+            action()
+        }
     }
 
     private var recentSection: some View {
@@ -574,15 +537,12 @@ struct ContentView: View {
             .padding(.bottom, 14)
             .frame(height: showAllRecents ? nil : 323)
         }
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(0.07))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
-                .shadow(color: shadowColor.opacity(0.55), radius: 22, x: 0, y: 14)
-                .shadow(color: .white.opacity(0.05), radius: 1, x: 0, y: 1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .appCardStyle(
+            primary: primary,
+            colorScheme: colorScheme,
+            fillOpacity: AppStyle.subtleCardFillOpacity,
+            shadowLevel: .medium
         )
         .padding(.horizontal, AppStyle.horizontalPadding)
         .padding(.bottom, 120)

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -10,9 +10,8 @@ struct ConversionSettingsView: View {
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { colorScheme == .dark ? .black : .white }
-    private var adaptiveBackground: Color { colorScheme == .dark ? Color(white: 0.1) : Color(white: 0.9) }
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var background: Color { AppStyle.background(for: colorScheme) }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     @State private var selectedFormat: AudioFormat = .mp3
     @State private var isProcessing = false
@@ -65,6 +64,7 @@ struct ConversionSettingsView: View {
                                 Capsule()
                                     .stroke(primary.opacity(0.15), lineWidth: 1)
                             )
+                            .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.3)
                     }
                 }
                 .padding(.top, 18)
@@ -145,61 +145,39 @@ struct ConversionSettingsView: View {
     private var settingsSection: some View {
         VStack(alignment: .leading, spacing: 18) {
             // File Size
-            ZStack {
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primary.opacity(0.09))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                    )
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("File Size")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                    HStack(spacing: 16) {
-                        Text("Original: \(fileSizeString(for: videoURL))")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                        Text("Estimated: \(estimatedExportSizeString())")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                    }
+            infoPanel {
+                Text("File Size")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                HStack(spacing: 16) {
+                    Text("Original: \(fileSizeString(for: videoURL))")
+                        .font(.system(size: 14))
+                        .foregroundStyle(primary.opacity(0.8))
+                    Text("Estimated: \(estimatedExportSizeString())")
+                        .font(.system(size: 14))
+                        .foregroundStyle(primary.opacity(0.8))
                 }
-                .padding(.vertical, 14)
-                .padding(.horizontal, 18)
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // Export Format
-            ZStack {
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primary.opacity(0.09))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                    )
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Format")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                    Text("Original: \(originalFormatLabel)")
+            infoPanel {
+                Text("Format")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text("Original: \(originalFormatLabel)")
+                    .font(.system(size: 14))
+                    .foregroundStyle(primary.opacity(0.8))
+                HStack {
+                    Text("When Exported:")
                         .font(.system(size: 14))
                         .foregroundStyle(primary.opacity(0.8))
-                    HStack {
-                        Text("When Exported:")
-                            .font(.system(size: 14))
-                            .foregroundStyle(primary.opacity(0.8))
-                        Picker("", selection: $selectedFormat) {
-                            Text("mp3").tag(AudioFormat.mp3)
-                            Text("wav").tag(AudioFormat.wav)
-                            Text("m4a").tag(AudioFormat.m4a)
-                        }
-                        .pickerStyle(.menu)
+                    Picker("", selection: $selectedFormat) {
+                        Text("mp3").tag(AudioFormat.mp3)
+                        Text("wav").tag(AudioFormat.wav)
+                        Text("m4a").tag(AudioFormat.m4a)
                     }
+                    .pickerStyle(.menu)
                 }
-                .padding(.vertical, 14)
-                .padding(.horizontal, 18)
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             // More… button
@@ -228,49 +206,38 @@ struct ConversionSettingsView: View {
                 if showAdvanced {
                     VStack(spacing: 18) {
                         // Bitrate setting
-                        ZStack {
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .fill(primary.opacity(0.09))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                                )
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text("Bitrate")
-                                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                        .foregroundStyle(primary)
-                                    Spacer()
-                                    Text(bitrateLabel)
-                                        .font(.system(size: 14))
-                                        .foregroundStyle(primary.opacity(0.8))
-                                    Button(action: {
-                                        withAnimation { showBitrateInfo.toggle() }
-                                    }) {
-                                        Image(systemName: "questionmark.circle")
-                                            .opacity(0.5)
-                                    }
-                                    .buttonStyle(.plain)
+                        infoPanel {
+                            HStack {
+                                Text("Bitrate")
+                                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(primary)
+                                Spacer()
+                                Text(bitrateLabel)
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(primary.opacity(0.8))
+                                Button(action: {
+                                    withAnimation { showBitrateInfo.toggle() }
+                                }) {
+                                    Image(systemName: "questionmark.circle")
+                                        .opacity(0.5)
                                 }
-                                if showBitrateInfo {
-                                    Text("Bitrate controls audio quality and file size.")
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(primary.opacity(0.7))
-                                        .transition(.opacity)
-                                }
-                                if selectedFormat == .wav {
-                                    Text("WAV exports keep the original quality (~\(wavBitrateKbps) kbps).")
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(primary.opacity(0.7))
-                                        .transition(.opacity)
-                                } else {
-                                    Slider(value: $bitrate, in: 64...320, step: 1)
-                                        .tint(accent.color)
-                                }
+                                .buttonStyle(.plain)
                             }
-                            .padding(.vertical, 14)
-                            .padding(.horizontal, 18)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            if showBitrateInfo {
+                                Text("Bitrate controls audio quality and file size.")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(primary.opacity(0.7))
+                                    .transition(.opacity)
+                            }
+                            if selectedFormat == .wav {
+                                Text("WAV exports keep the original quality (~\(wavBitrateKbps) kbps).")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(primary.opacity(0.7))
+                                    .transition(.opacity)
+                            } else {
+                                Slider(value: $bitrate, in: 64...320, step: 1)
+                                    .tint(accent.color)
+                            }
                         }
                         // Add more advanced settings here as needed
 
@@ -297,6 +264,16 @@ struct ConversionSettingsView: View {
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private func infoPanel<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            content()
+        }
+        .padding(.vertical, 14)
+        .padding(.horizontal, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .medium)
     }
 
     // MARK: - Helpers
@@ -666,6 +643,7 @@ private struct VideoPreviewCard: View {
     let size: CGFloat
     let primaryColor: Color
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var thumbnail: UIImage?
     @State private var player: AVPlayer?
     @State private var isPlaying = false
@@ -723,6 +701,7 @@ private struct VideoPreviewCard: View {
             }
         }
         .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
         .onTapGesture {
             showControls = true
             resetHideControlsTimer()
@@ -854,6 +833,7 @@ private struct AudioPreviewCard: View {
     let accentColor: Color
     @Binding var audioURL: URL?
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var player: AVPlayer?
     @State private var isPlaying = false
     @State private var endObserver: NSObjectProtocol?
@@ -896,8 +876,9 @@ private struct AudioPreviewCard: View {
                     .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
             }
         }
-        
+
         .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
         .onTapGesture {
             guard audioURL != nil else { return }
             togglePlayback()

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
 
-    private var primary: Color { colorScheme == .dark ? .white : .black }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     private var versionDisplayString: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
@@ -187,6 +187,7 @@ struct SettingsView: View {
                     .padding(.vertical, 10)
                     .background(accent.color.opacity(0.25))
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
             }
             .padding(.top, 4)
         }
@@ -218,6 +219,7 @@ struct SettingsView: View {
                     .padding(.vertical, 10)
                     .background(accent.color.opacity(0.25))
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
             }
             .padding(.top, 12)
         }
@@ -255,15 +257,11 @@ struct SettingsView: View {
         }
         .padding(AppStyle.innerPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(0.07))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(0.10), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.55), radius: 22, x: 0, y: 14)
-                .shadow(color: colorScheme == .dark ? Color.white.opacity(0.05) : Color.white.opacity(0.3), radius: 1, x: 0, y: 1)
+        .appCardStyle(
+            primary: primary,
+            colorScheme: colorScheme,
+            fillOpacity: AppStyle.subtleCardFillOpacity,
+            shadowLevel: .medium
         )
         .padding(.horizontal, AppStyle.horizontalPadding)
     }


### PR DESCRIPTION
## Summary
- add reusable card and shadow helpers to `AppStyle` so UI components share one styling source
- refactor the home source picker and recents sections to use the shared styling utilities
- update settings panels, recent rows, gallery thumbnails, and conversion flow cards to adopt the unified shadows

## Testing
- not run (iOS app project)

------
https://chatgpt.com/codex/tasks/task_e_68ce06bbd2288320ba54ba1d910c4124