### PR TITLE
Modernize AV usage and improve gallery performance

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -212,7 +212,7 @@ struct ContentView: View {
                 }
             }
         }
-        .onChange(of: selectedTab) { newValue in
+        .onChange(of: selectedTab) { _, newValue in
             if showSourceOptions {
                 withAnimation(.easeInOut(duration: 0.35)) {
                     showSourceOptions = false
@@ -222,7 +222,7 @@ struct ContentView: View {
                 withAnimation { selectedAsset = nil }
             }
         }
-        .onChange(of: selectedAsset) { asset in
+        .onChange(of: selectedAsset) { _, asset in
             if let asset = asset {
                 let options = PHVideoRequestOptions()
                 options.isNetworkAccessAllowed = true
@@ -301,7 +301,7 @@ struct ContentView: View {
                     .opacity(showHomeTopBorder ? 1 : 0)
                     .animation(.easeInOut(duration: 0.2), value: showHomeTopBorder)
             }
-            .onChange(of: homeScrollTrigger) { _ in
+            .onChange(of: homeScrollTrigger) { _, _ in
                 withAnimation {
                     proxy.scrollTo("top", anchor: .top)
                 }
@@ -354,7 +354,7 @@ struct ContentView: View {
                     .opacity(showGalleryTopBorder ? 1 : 0)
                     .animation(.easeInOut(duration: 0.2), value: showGalleryTopBorder)
             }
-            .onChange(of: galleryScrollTrigger) { _ in
+            .onChange(of: galleryScrollTrigger) { _, _ in
                 withAnimation {
                     proxy.scrollTo("top", anchor: .top)
                 }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -70,7 +70,7 @@ struct SettingsView: View {
                     .opacity(showTopBorder ? 1 : 0)
                     .animation(.easeInOut(duration: 0.2), value: showTopBorder)
             }
-            .onChange(of: scrollToTopTrigger) { _ in
+            .onChange(of: scrollToTopTrigger) { _, _ in
                 withAnimation {
                     proxy.scrollTo("top", anchor: .top)
                 }
@@ -153,7 +153,7 @@ struct SettingsView: View {
                 Text("Vibration")
                     .foregroundStyle(primary.opacity(0.9))
             }
-            .onChange(of: hapticsEnabled) { _ in
+            .onChange(of: hapticsEnabled) { _, _ in
                 HapticsManager.shared.selection()
             }
 
@@ -161,7 +161,7 @@ struct SettingsView: View {
                 Text("Sounds")
                     .foregroundStyle(primary.opacity(0.9))
             }
-            .onChange(of: soundsEnabled) { _ in
+            .onChange(of: soundsEnabled) { _, _ in
                 HapticsManager.shared.selection()
             }
 
@@ -169,7 +169,7 @@ struct SettingsView: View {
                 Text("Experimental Features")
                     .foregroundStyle(primary.opacity(0.9))
             }
-            .onChange(of: experimentalEnabled) { _ in
+            .onChange(of: experimentalEnabled) { _, _ in
                 HapticsManager.shared.selection()
             }
 


### PR DESCRIPTION
## Summary
- replace deprecated `onChange` overloads with the iOS 17 variants across ContentView and Settings
- overhaul the gallery to cache sections, prefetch thumbnails, and load durations asynchronously for smoother scrolling
- migrate ConversionSettingsView previews and VideoToAudioConverter to the async AVFoundation APIs with safe concurrency handling

## Testing
- xcodebuild (fails: command not found in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce0bcd186c8320822577c66de4b4a9