### PR TITLE
Refine main interface layout

### DIFF
--- a/Resonans/Components/InlineToastView.swift
+++ b/Resonans/Components/InlineToastView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct InlineToastView: View {
+    let message: String
+    let tint: Color
+    let primaryColor: Color
+    let iconName: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: iconName)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(primaryColor.opacity(0.9))
+                .padding(8)
+                .background(primaryColor.opacity(0.12))
+                .clipShape(Circle())
+
+            Text(message)
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .foregroundStyle(primaryColor)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                .fill(tint.opacity(0.82))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                .stroke(primaryColor.opacity(0.08), lineWidth: 1)
+        )
+        .shadow(color: tint.opacity(0.4), radius: 18, x: 0, y: 12)
+    }
+}
+
+#Preview {
+    InlineToastView(message: "Clip ready – tap Extract to continue.", tint: .purple, primaryColor: .white, iconName: "checkmark.seal.fill")
+        .padding()
+        .background(Color.black)
+}

--- a/Resonans/Components/ResonansNavigationBar.swift
+++ b/Resonans/Components/ResonansNavigationBar.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct ResonansNavigationBar: View {
+    let title: String
+    let subtitle: String
+    let accentColor: Color
+    let primaryColor: Color
+    var onHelp: (() -> Void)?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 42, weight: .heavy, design: .rounded))
+                        .foregroundStyle(primaryColor)
+                        .minimumScaleFactor(0.8)
+                        .lineLimit(1)
+                        .appTextShadow(colorScheme: colorScheme)
+
+                    Text(subtitle)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(primaryColor.opacity(0.65))
+                }
+
+                Spacer()
+
+                if let onHelp {
+                    Button(action: onHelp) {
+                        Image(systemName: "questionmark.circle")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(primaryColor)
+                            .padding(12)
+                            .background(
+                                Circle()
+                                    .fill(primaryColor.opacity(AppStyle.cardFillOpacity))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
+                }
+            }
+
+            Capsule()
+                .fill(accentColor.opacity(0.45))
+                .frame(width: 82, height: 6)
+                .shadow(color: accentColor.opacity(0.35), radius: 8, x: 0, y: 4)
+        }
+        .padding(.top, 16)
+        .padding(.horizontal, AppStyle.horizontalPadding)
+        .padding(.bottom, 12)
+    }
+}
+
+#Preview {
+    ResonansNavigationBar(
+        title: "Resonans",
+        subtitle: "Convert clips into studio-grade audio.",
+        accentColor: .purple,
+        primaryColor: .white,
+        onHelp: {}
+    )
+    .background(Color.black)
+}

--- a/Resonans/Components/ResonansTabBar.swift
+++ b/Resonans/Components/ResonansTabBar.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ResonansTabBar: View {
+    @Binding var selectedTab: MainTab
+    let accentColor: Color
+    let primaryColor: Color
+    let onReselect: (MainTab) -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(MainTab.allCases) { tab in
+                Button {
+                    HapticsManager.shared.pulse()
+                    if selectedTab == tab {
+                        onReselect(tab)
+                    } else {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            selectedTab = tab
+                        }
+                    }
+                } label: {
+                    VStack(spacing: 6) {
+                        Image(systemName: tab.iconName)
+                            .font(.system(size: 20, weight: .semibold))
+                        Text(tab.shortTitle)
+                            .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    }
+                    .foregroundStyle(selectedTab == tab ? Color.white : primaryColor.opacity(0.65))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 22, style: .continuous)
+                            .fill(
+                                selectedTab == tab
+                                    ? accentColor
+                                    : primaryColor.opacity(AppStyle.compactCardFillOpacity)
+                            )
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .fill(primaryColor.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                        .stroke(primaryColor.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
+    }
+}
+
+#Preview {
+    ResonansTabBar(
+        selectedTab: .constant(.home),
+        accentColor: .purple,
+        primaryColor: .white,
+        onReselect: { _ in }
+    )
+    .padding()
+    .background(Color.black)
+}

--- a/Resonans/Components/SourceSelectionSheet.swift
+++ b/Resonans/Components/SourceSelectionSheet.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+struct SourceSelectionSheet: View {
+    let accentColor: Color
+    let primaryColor: Color
+    let onImportFromLibrary: () -> Void
+    let onImportFromFiles: () -> Void
+    let onOpenGallery: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Capsule()
+                .fill(primaryColor.opacity(0.15))
+                .frame(width: 48, height: 6)
+                .padding(.top, 6)
+
+            VStack(spacing: 8) {
+                Text("Choose a source")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .foregroundStyle(primaryColor)
+
+                Text("Import directly from Photos or Files, or jump to the gallery to stage an existing clip.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(primaryColor.opacity(0.7))
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 12)
+
+            Button(action: onImportFromLibrary) {
+                HStack {
+                    Image(systemName: "photo.fill")
+                    Text("Pick from Photos")
+                        .fontWeight(.semibold)
+                }
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(accentColor)
+                .clipShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
+            }
+            .buttonStyle(.plain)
+
+            HStack(spacing: 14) {
+                SourceQuickAction(
+                    title: "Files",
+                    subtitle: "Browse documents",
+                    icon: "folder.fill",
+                    accentColor: accentColor,
+                    primaryColor: primaryColor,
+                    action: onImportFromFiles
+                )
+
+                SourceQuickAction(
+                    title: "Gallery",
+                    subtitle: "Latest clips",
+                    icon: "rectangle.stack.fill",
+                    accentColor: accentColor,
+                    primaryColor: primaryColor,
+                    action: onOpenGallery
+                )
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primaryColor.opacity(colorScheme == .dark ? 0.24 : 0.08))
+                .ignoresSafeArea()
+        )
+        .presentationBackground(.ultraThinMaterial)
+    }
+}
+
+private struct SourceQuickAction: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let accentColor: Color
+    let primaryColor: Color
+    let action: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 36, height: 36)
+                    .background(accentColor.opacity(0.18))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primaryColor)
+
+                Text(subtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(primaryColor.opacity(0.6))
+                    .multilineTextAlignment(.leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(18)
+            .appCardStyle(
+                primary: primaryColor,
+                colorScheme: colorScheme,
+                cornerRadius: AppStyle.compactCornerRadius,
+                fillOpacity: AppStyle.compactCardFillOpacity,
+                shadowLevel: .small
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    SourceSelectionSheet(
+        accentColor: .purple,
+        primaryColor: .white,
+        onImportFromLibrary: {},
+        onImportFromFiles: {},
+        onOpenGallery: {}
+    )
+    .background(Color.black)
+}


### PR DESCRIPTION
## Summary
- Rebuilt the main workspace to use a segmented layout with a hero conversion card, quick actions, and richer gallery/recents sections for a clearer professional experience.
- Added reusable navigation, tab, toast, and source-selection components to unify styling and provide consistent entry points into conversions.
- Improved feedback around video selection by coordinating sheet presentation, state resets, and contextual toast messaging.

## Testing
- Not run (iOS SwiftUI project; no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d06e77b5c083208b1b76be6a786a1c