### PR TITLE
Refactor home, tools, and onboarding experience

### DIFF
--- a/Resonans/Models/AppNewsItem.swift
+++ b/Resonans/Models/AppNewsItem.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct AppNewsItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+    let date: Date
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}

--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -10,6 +10,7 @@ struct ToolItem: Identifiable {
     let subtitle: String
     let iconName: String
     let gradientColors: [Color]
+    let destination: () -> AnyView
 
     static let audioExtractor = ToolItem(
         id: .audioExtractor,
@@ -19,7 +20,8 @@ struct ToolItem: Identifiable {
         gradientColors: [
             Color(red: 0.49, green: 0.33, blue: 0.95),
             Color(red: 0.58, green: 0.41, blue: 0.98)
-        ]
+        ],
+        destination: { AnyView(AudioExtractorView()) }
     )
 
     static let all: [ToolItem] = [

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,41 +1,50 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var videoURL: URL?
-    @State private var showPhotoPicker = false
-    @State private var showFilePicker = false
-    @State private var message: String?
-    @State private var showSourceSheet = false
-    @State private var showToast = false
-    @State private var toastColor: Color = .green
-    @State private var showSourceOptions = false
-    @State private var showConversionSheet = false
-    
-    // Recent conversions
-    @State private var recents: [RecentItem] = [
-
-    ]
-    @State private var showAllRecents = false
-
     @State private var selectedTab: Int = 0
 
     @State private var homeScrollTrigger = false
     @State private var toolsScrollTrigger = false
     @State private var settingsScrollTrigger = false
-    @State private var showHomeTopBorder = false
-    @State private var showToolsTopBorder = false
+
+    @State private var message: String?
+    @State private var showToast = false
+    @State private var toastColor: Color = .green
 
     private let tools = ToolItem.all
     @State private var selectedTool: ToolItem.Identifier = .audioExtractor
+    @State private var favoriteToolIDs: Set<ToolItem.Identifier> = [.audioExtractor]
+    @State private var recentToolIDs: [ToolItem.Identifier] = []
+    @State private var newsItems: [AppNewsItem] = [
+        AppNewsItem(
+            title: "Interactive onboarding arrives",
+            description: "Learn the essentials of Resonans with a guided tour that adapts to your creative flow.",
+            date: Date()
+        ),
+        AppNewsItem(
+            title: "Audio extractor gets a fresh coat",
+            description: "A new streamlined launcher with quick file access keeps your exports on point.",
+            date: Calendar.current.date(byAdding: .day, value: -5, to: Date()) ?? Date()
+        )
+    ]
 
+    @State private var toolLaunchRequest: ToolItem.Identifier?
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @AppStorage("showGuidedTips") private var showGuidedTips = true
+    @State private var showOnboarding = false
+
     @Environment(\.colorScheme) private var colorScheme
     private var background: Color { AppStyle.background(for: colorScheme) }
     private var primary: Color { AppStyle.primary(for: colorScheme) }
-    private var activeTool: ToolItem? { tools.first { $0.id == selectedTool } }
+
+    private var favoriteTools: [ToolItem] { tools.filter { favoriteToolIDs.contains($0.id) } }
+    private var recentTools: [ToolItem] {
+        recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
+    }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -48,6 +57,7 @@ struct ContentView: View {
                     )
                     .ignoresSafeArea()
                 )
+
             VStack(spacing: 0) {
                 header
                 ZStack {
@@ -59,89 +69,34 @@ struct ContentView: View {
                     }
                     .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
                     .animation(.easeInOut(duration: 0.3), value: selectedTab)
-                    .overlay(
-                        LinearGradient(
-                            gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                            startPoint: .bottom,
-                            endPoint: .top
-                        )
-                        .frame(height: 200) // increased height so fade starts lower
-                        .allowsHitTesting(false),
-                        alignment: .bottom
-                    )
-                    // Custom Tab Bar pinned at the bottom with gradient background
+
                     VStack {
                         Spacer()
                         ZStack {
-                        LinearGradient(
-                            gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                            startPoint: .bottom,
-                            endPoint: .top
-                        )
-                        .frame(height: 80)
-                        .ignoresSafeArea(edges: .bottom)
+                            LinearGradient(
+                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
+                                startPoint: .bottom,
+                                endPoint: .top
+                            )
+                            .frame(height: 80)
+                            .ignoresSafeArea(edges: .bottom)
+
                             HStack {
                                 Spacer()
-                                Button(action: {
-                                    HapticsManager.shared.pulse()
-                                    if selectedTab == 0 {
-                                        homeScrollTrigger.toggle()
-                                    } else {
-                                        selectedTab = 0
-                                        DispatchQueue.main.async {
-                                            homeScrollTrigger.toggle()
-                                        }
-                                    }
-                                }) {
-                                    Image(systemName: "house.fill")
-                                        .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 0 ? accent.color : primary.opacity(0.5))
-                                        .animation(.easeInOut(duration: 0.25), value: selectedTab)
-                                }
+                                bottomTabButton(systemName: "house.fill", tab: 0, trigger: $homeScrollTrigger)
                                 Spacer()
-                                Button(action: {
-                                    HapticsManager.shared.pulse()
-                                    if selectedTab == 1 {
-                                        toolsScrollTrigger.toggle()
-                                    } else {
-                                        selectedTab = 1
-                                        DispatchQueue.main.async {
-                                            toolsScrollTrigger.toggle()
-                                        }
-                                    }
-                                }) {
-                                    Image(systemName: "wrench.and.screwdriver.fill")
-                                        .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 1 ? accent.color : primary.opacity(0.5))
-                                        .animation(.easeInOut(duration: 0.25), value: selectedTab)
-                                }
+                                bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: 1, trigger: $toolsScrollTrigger)
                                 Spacer()
-                                Button(action: {
-                                    HapticsManager.shared.pulse()
-                                    if selectedTab == 2 {
-                                        settingsScrollTrigger.toggle()
-                                    } else {
-                                        selectedTab = 2
-                                        DispatchQueue.main.async {
-                                            settingsScrollTrigger.toggle()
-                                        }
-                                    }
-                                }) {
-                                    Image(systemName: "gearshape.fill")
-                                        .font(.system(size: 24, weight: .semibold))
-                                        .foregroundStyle(selectedTab == 2 ? accent.color : primary.opacity(0.5))
-                                        .animation(.easeInOut(duration: 0.25), value: selectedTab)
-                                }
+                                bottomTabButton(systemName: "gearshape.fill", tab: 2, trigger: $settingsScrollTrigger)
                                 Spacer()
                             }
                             .padding(.horizontal, 40)
                             .padding(.vertical, 12)
-                            .padding(.bottom, 0)
                         }
                     }
                 }
             }
-            // Toast overlay at the very top
+
             if showToast, let msg = message {
                 VStack {
                     HStack {
@@ -155,7 +110,7 @@ struct ContentView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         Spacer()
                     }
-                    .padding(.top, 44) // closer to the top safe area
+                    .padding(.top, 44)
                     Spacer()
                 }
                 .transition(.move(edge: .top).combined(with: .opacity))
@@ -172,130 +127,31 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.4), value: colorScheme)
         .animation(.easeInOut(duration: 0.4), value: accent)
         .contentShape(Rectangle())
-        .onTapGesture {
-            if showSourceOptions {
-                HapticsManager.shared.selection()
-                withAnimation(.easeInOut(duration: 0.35)) {
-                    showSourceOptions = false
-                }
+        .onAppear {
+            if !hasCompletedOnboarding {
+                showOnboarding = true
             }
         }
-        .onChange(of: selectedTab) { _, newValue in
-            if showSourceOptions {
-                withAnimation(.easeInOut(duration: 0.35)) {
-                    showSourceOptions = false
-                }
-            }
-        }
-        // Removed unused .confirmationDialog
-        .sheet(isPresented: $showPhotoPicker) {
-            VideoPicker { url in
-                videoURL = url
-                showConversionSheet = true
-            }
-        }
-        .sheet(isPresented: $showFilePicker) {
-            FilePicker { url in
-                videoURL = url
-                showConversionSheet = true
-            }
-        }
-        .sheet(
-            isPresented: $showConversionSheet,
-            onDismiss: {
-                videoURL = nil
-            }
-        ) {
-            if let url = videoURL {
-                ConversionSettingsView(videoURL: url)
+        .fullScreenCover(isPresented: $showOnboarding) {
+            OnboardingFlowView(
+                tools: tools,
+                accent: accent.color,
+                primary: primary,
+                colorScheme: colorScheme
+            ) { favorites, tips in
+                favoriteToolIDs = favorites
+                showGuidedTips = tips
+                hasCompletedOnboarding = true
+                showOnboarding = false
+                presentToast("You're all set! Let's create.", color: accent.color)
             }
         }
     }
-
-    // MARK: - Tabs
-
-    private var homeTab: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 24) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .padding(.bottom, -24)
-                        .id("top")
-                    addCard
-                        .background(
-                            GeometryReader { geo -> Color in
-                                DispatchQueue.main.async {
-                                    let show = geo.frame(in: .named("homeScroll")).minY < 0
-                                    if showHomeTopBorder != show {
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            showHomeTopBorder = show
-                                        }
-                                    }
-                                }
-                                return Color.clear
-                            }
-                        )
-                    recentSection
-                    Spacer(minLength: 40)
-                }
-            }
-            .coordinateSpace(name: "homeScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.5))
-                    .frame(height: 1)
-                    .opacity(showHomeTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showHomeTopBorder)
-            }
-            .onChange(of: homeScrollTrigger) { _, _ in
-                withAnimation {
-                    proxy.scrollTo("top", anchor: .top)
-                }
-            }
-        }
-    }
-
-    private var toolsTab: some View {
-        ToolsView(
-            tools: tools,
-            selectedTool: $selectedTool,
-            scrollToTopTrigger: $toolsScrollTrigger,
-            accent: accent,
-            primary: primary,
-            colorScheme: colorScheme
-        ) { tool, isNewSelection in
-            let text = isNewSelection ? "\(tool.title) ready." : "\(tool.title) already active."
-            presentToast(text, color: accent.color)
-        }
-        .background(
-            GeometryReader { geo -> Color in
-                DispatchQueue.main.async {
-                    let show = geo.frame(in: .named("toolsScroll")).minY < -24
-                    if showToolsTopBorder != show {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            showToolsTopBorder = show
-                        }
-                    }
-                }
-                return Color.clear
-            }
-        )
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(Color.gray.opacity(0.5))
-                .frame(height: 1)
-                .opacity(showToolsTopBorder ? 1 : 0)
-                .animation(.easeInOut(duration: 0.2), value: showToolsTopBorder)
-        }
-    }
-
-    // MARK: - Subviews
 
     private var header: some View {
         HStack(alignment: .center) {
             ZStack(alignment: .leading) {
-                Text("Resonans")
+                Text("Home")
                     .opacity(selectedTab == 0 ? 1 : 0)
                 Text("Tools")
                     .opacity(selectedTab == 1 ? 1 : 0)
@@ -308,10 +164,12 @@ struct ContentView: View {
             .padding(.leading, 22)
             .appTextShadow(colorScheme: colorScheme)
             .animation(.easeInOut(duration: 0.25), value: selectedTab)
+
             Spacer()
+
             Button(action: {
                 HapticsManager.shared.pulse()
-                /* TODO: show help */
+                showOnboarding = true
             }) {
                 Image(systemName: "questionmark.circle")
                     .font(.system(size: 26, weight: .semibold))
@@ -323,199 +181,83 @@ struct ContentView: View {
         }
     }
 
-    private var addCard: some View {
-        GeometryReader { geo in
-            let fullWidth = geo.size.width - (AppStyle.horizontalPadding * 2) // horizontal padding
-            let targetWidth = (fullWidth - 16) / 2
-            ZStack {
-                if showSourceOptions {
-                    background.opacity(0.001)
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                showSourceOptions = false
-                            }
-                        }
-                }
-                primarySourceCard(width: fullWidth)
-                HStack(spacing: 16) {
-                    sourceOptionCard(icon: "doc.fill", title: "Files", width: targetWidth) {
-                        showFilePicker = true
-                        withAnimation(.easeInOut(duration: 0.35)) {
-                            showSourceOptions = false
-                        }
-                    }
-                    sourceOptionCard(icon: "photo.on.rectangle.angled", title: "Photo Library", width: targetWidth) {
-                        showPhotoPicker = true
-                        withAnimation(.easeInOut(duration: 0.35)) {
-                            showSourceOptions = false
-                        }
-                    }
-                }
-                .scaleEffect(showSourceOptions ? 1.0 : 0.75)
-                .animation(.spring(response: 0.45, dampingFraction: 0.6, blendDuration: 0), value: showSourceOptions)
-                .opacity(showSourceOptions ? 1.0 : 0.0)
-                .animation(.easeInOut(duration: 0.3), value: showSourceOptions)
-                .allowsHitTesting(showSourceOptions)
-                .zIndex(showSourceOptions ? 1 : 0)
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
-            .frame(height: 165)
-            .gesture(
-                DragGesture(minimumDistance: 24, coordinateSpace: .local)
-                    .onEnded { value in
-                        if abs(value.translation.width) > abs(value.translation.height), abs(value.translation.width) > 36 {
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                showSourceOptions = false
-                            }
-                        }
-                    }
-            )
-        }
-        .frame(height: 165)
-    }
-
-    private func primarySourceCard(width: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 10) {
-                Image(systemName: "wand.and.stars")
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundStyle(primary.opacity(0.85))
-                Text("Active tool")
-                    .font(.system(size: 15, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.75))
-                Spacer()
-                if let tool = activeTool {
-                    Label(tool.title, systemImage: "checkmark.seal.fill")
-                        .font(.system(size: 14, weight: .semibold, design: .rounded))
-                        .labelStyle(.titleAndIcon)
-                        .foregroundStyle(accent.color)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(
-                            Capsule()
-                                .fill(accent.color.opacity(colorScheme == .dark ? 0.15 : 0.12))
-                                .overlay(
-                                    Capsule()
-                                        .strokeBorder(accent.color.opacity(0.25), lineWidth: 1)
-                                )
-                        )
-                }
-            }
-
-            if let tool = activeTool {
-                Text(tool.title)
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
-                Text(tool.subtitle)
-                    .font(.system(size: 15, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
-                    .lineLimit(2)
-            } else {
-                Text("Choose a tool to get started")
-                    .font(.system(size: 24, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-            }
-
-            Spacer()
-
-            HStack(spacing: 10) {
-                Image(systemName: "hand.tap.fill")
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(primary.opacity(0.6))
-                Text("Tap to pick a video")
-                    .font(.system(size: 14, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.6))
-            }
-        }
-        .padding(.horizontal, AppStyle.innerPadding)
-        .padding(.vertical, AppStyle.innerPadding)
-        .frame(width: width, height: 165)
-        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
-        .onTapGesture {
-            HapticsManager.shared.pulse()
-            withAnimation(.easeInOut(duration: 0.35)) {
-                showSourceOptions = true
-            }
-        }
-        .scaleEffect(showSourceOptions ? 0.75 : 1.0)
-        .animation(.spring(response: 0.45, dampingFraction: 0.6, blendDuration: 0), value: showSourceOptions)
-        .opacity(showSourceOptions ? 0.0 : 1.0)
-        .animation(.easeInOut(duration: 0.3), value: showSourceOptions)
-        .allowsHitTesting(!showSourceOptions)
-        .zIndex(showSourceOptions ? 0 : 1)
-    }
-
-    private func sourceOptionCard(icon: String, title: String, width: CGFloat, action: @escaping () -> Void) -> some View {
-        VStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.system(size: 36, weight: .bold))
-                .foregroundStyle(primary)
-            Text(title)
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
-        }
-        .frame(width: width, height: 165)
-        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
-        .onTapGesture {
-            HapticsManager.shared.pulse()
-            action()
-        }
-    }
-
-    private var recentSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Title inside the box
-            Text("Recent conversions")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.top, 16)
-                .padding(.horizontal, AppStyle.innerPadding)
-
-            VStack(spacing: 12) {
-                if recents.isEmpty {
-                    Text("None yet")
-                        .font(.system(size: 18, weight: .regular, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.6))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                } else {
-                    ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
-                        RecentRow(item: item)
-                            .padding(.horizontal, 12)
-                    }
-                    if recents.count > 3 {
-                        Button(action: {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.25)) {
-                                showAllRecents.toggle()
-                            }
-                        }) {
-                            Text(showAllRecents ? "Show less" : "Show more")
-                                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.8))
-                        }
-                        .padding(.top, 4)
-                    }
-                }
-            }
-            .padding(.top, 10)
-            .padding(.bottom, 14)
-            .frame(height: showAllRecents ? nil : 323)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .appCardStyle(
+    private var homeTab: some View {
+        HomeDashboardView(
+            tools: tools,
+            favoriteTools: favoriteTools,
+            recentTools: recentTools,
+            newsItems: newsItems,
+            scrollToTopTrigger: $homeScrollTrigger,
+            accent: accent,
             primary: primary,
             colorScheme: colorScheme,
-            fillOpacity: AppStyle.subtleCardFillOpacity,
-            shadowLevel: .medium
+            onOpenTool: { launchTool($0) },
+            onToggleFavorite: { toggleFavorite($0) },
+            onShowTools: { selectedTab = 1 }
         )
-        .padding(.horizontal, AppStyle.horizontalPadding)
-        .padding(.bottom, 120)
     }
 
-    // statusMessage is no longer needed; replaced by toast overlay
+    private var toolsTab: some View {
+        ToolsView(
+            tools: tools,
+            selectedTool: $selectedTool,
+            scrollToTopTrigger: $toolsScrollTrigger,
+            pendingLaunch: $toolLaunchRequest,
+            accent: accent,
+            primary: primary,
+            colorScheme: colorScheme
+        ) { tool, isNewSelection in
+            let text = isNewSelection ? "\(tool.title) ready." : "\(tool.title) already active."
+            presentToast(text, color: accent.color)
+        } onOpen: { tool in
+            updateRecents(with: tool.id)
+        }
+    }
 
-    // MARK: - Actions
+    private func bottomTabButton(systemName: String, tab: Int, trigger: Binding<Bool>) -> some View {
+        Button(action: {
+            HapticsManager.shared.pulse()
+            if selectedTab == tab {
+                trigger.wrappedValue.toggle()
+            } else {
+                selectedTab = tab
+                DispatchQueue.main.async {
+                    trigger.wrappedValue.toggle()
+                }
+            }
+        }) {
+            Image(systemName: systemName)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(selectedTab == tab ? accent.color : primary.opacity(0.5))
+                .animation(.easeInOut(duration: 0.25), value: selectedTab)
+        }
+    }
+
+    private func launchTool(_ tool: ToolItem) {
+        selectedTool = tool.id
+        updateRecents(with: tool.id)
+        presentToast("\(tool.title) ready.", color: accent.color)
+        toolLaunchRequest = tool.id
+        if selectedTab != 1 {
+            selectedTab = 1
+        }
+    }
+
+    private func toggleFavorite(_ identifier: ToolItem.Identifier) {
+        if favoriteToolIDs.contains(identifier) {
+            favoriteToolIDs.remove(identifier)
+        } else {
+            favoriteToolIDs.insert(identifier)
+        }
+    }
+
+    private func updateRecents(with identifier: ToolItem.Identifier) {
+        recentToolIDs.removeAll(where: { $0 == identifier })
+        recentToolIDs.insert(identifier, at: 0)
+        if recentToolIDs.count > 6 {
+            recentToolIDs = Array(recentToolIDs.prefix(6))
+        }
+    }
 
     private func presentToast(_ text: String, color: Color) {
         message = text

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -1,0 +1,419 @@
+import SwiftUI
+
+struct HomeDashboardView: View {
+    let tools: [ToolItem]
+    let favoriteTools: [ToolItem]
+    let recentTools: [ToolItem]
+    let newsItems: [AppNewsItem]
+    @Binding var scrollToTopTrigger: Bool
+
+    let accent: AccentColorOption
+    let primary: Color
+    let colorScheme: ColorScheme
+
+    let onOpenTool: (ToolItem) -> Void
+    let onToggleFavorite: (ToolItem.Identifier) -> Void
+    let onShowTools: () -> Void
+
+    @State private var showTopBorder = false
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 28) {
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .padding(.bottom, -24)
+                        .id("homeTop")
+
+                    heroCard
+                        .background(
+                            GeometryReader { geo -> Color in
+                                DispatchQueue.main.async {
+                                    let shouldShow = geo.frame(in: .named("homeScroll")).minY < 0
+                                    if showTopBorder != shouldShow {
+                                        withAnimation(.easeInOut(duration: 0.25)) {
+                                            showTopBorder = shouldShow
+                                        }
+                                    }
+                                }
+                                return Color.clear
+                            }
+                        )
+                        .padding(.horizontal, AppStyle.horizontalPadding)
+
+                    favoritesSection
+                    recentsSection
+                    newsSection
+
+                    Spacer(minLength: 60)
+                }
+            }
+            .coordinateSpace(name: "homeScroll")
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.45))
+                    .frame(height: 1)
+                    .opacity(showTopBorder ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
+            }
+            .onChange(of: scrollToTopTrigger) { _, _ in
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
+                    proxy.scrollTo("homeTop", anchor: .top)
+                }
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Welcome back")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                    Text("Craft something brilliant today")
+                        .font(.system(size: 30, weight: .heavy, design: .rounded))
+                        .foregroundStyle(primary)
+                }
+
+                Spacer()
+
+                VStack(spacing: 8) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundStyle(accent.color)
+                    Text("v1.2")
+                        .font(.system(size: 12, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.6))
+                }
+            }
+
+            Text("Pin your favourite workflows, hop into tools in one tap and keep an eye on what's new in Resonans.")
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.7))
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                Button {
+                    HapticsManager.shared.selection()
+                    onShowTools()
+                } label: {
+                    Label("Browse tools", systemImage: "wrench.and.screwdriver")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 18)
+                        .background(accent.color.opacity(colorScheme == .dark ? 0.3 : 0.15))
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(accent.color.opacity(0.4), lineWidth: 1)
+                        )
+                        .foregroundStyle(accent.color)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    HapticsManager.shared.selection()
+                    if let firstFavorite = favoriteTools.first ?? tools.first {
+                        onOpenTool(firstFavorite)
+                    }
+                } label: {
+                    Label("Quick start", systemImage: "play.circle.fill")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 18)
+                        .background(primary.opacity(AppStyle.cardFillOpacity))
+                        .clipShape(Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                        )
+                        .foregroundStyle(primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(AppStyle.innerPadding)
+        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
+    }
+
+    private var favoritesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Favorite tools")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundStyle(primary)
+                Spacer()
+                if !favoriteTools.isEmpty {
+                    Text("Tap to toggle")
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.55))
+                }
+            }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+
+            if tools.isEmpty {
+                Text("No tools available yet.")
+                    .font(.system(size: 16, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                    .frame(maxWidth: .infinity)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 14) {
+                        ForEach(tools) { tool in
+                            FavoriteToolChip(
+                                tool: tool,
+                                isFavorite: favoriteTools.contains(where: { $0.id == tool.id }),
+                                primary: primary,
+                                accent: accent.color,
+                                colorScheme: colorScheme,
+                                onToggle: { onToggleFavorite(tool.id) },
+                                onOpen: { onOpenTool(tool) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, AppStyle.horizontalPadding)
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+    }
+
+    private var recentsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Recently used")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundStyle(primary)
+                Spacer()
+            }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+
+            if recentTools.isEmpty {
+                Text("Jump back into tools and your history will live here.")
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.65))
+                    .padding(.horizontal, AppStyle.horizontalPadding)
+                    .padding(.vertical, 28)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                            .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                    .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                            )
+                    )
+                    .appShadow(colorScheme: colorScheme, level: .medium)
+                    .padding(.horizontal, AppStyle.horizontalPadding)
+            } else {
+                VStack(spacing: 12) {
+                    ForEach(recentTools) { tool in
+                        Button {
+                            HapticsManager.shared.selection()
+                            onOpenTool(tool)
+                        } label: {
+                            ToolHistoryRow(tool: tool, primary: primary, colorScheme: colorScheme)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, AppStyle.horizontalPadding)
+            }
+        }
+    }
+
+    private var newsSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("App news")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(primary)
+                .padding(.horizontal, AppStyle.horizontalPadding)
+
+            VStack(spacing: 16) {
+                if newsItems.isEmpty {
+                    Text("Fresh updates will appear here after our next release.")
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 32)
+                } else {
+                    ForEach(newsItems) { news in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(news.formattedDate.uppercased())
+                                .font(.system(size: 11, weight: .bold, design: .rounded))
+                                .foregroundStyle(primary.opacity(0.45))
+                            Text(news.title)
+                                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                                .foregroundStyle(primary)
+                            Text(news.description)
+                                .font(.system(size: 14, weight: .medium, design: .rounded))
+                                .foregroundStyle(primary.opacity(0.7))
+                        }
+                        .padding(AppStyle.innerPadding)
+                        .background(
+                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                                )
+                        )
+                        .appShadow(colorScheme: colorScheme, level: .small)
+                    }
+                }
+            }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+        }
+    }
+}
+
+private struct FavoriteToolChip: View {
+    let tool: ToolItem
+    let isFavorite: Bool
+    let primary: Color
+    let accent: Color
+    let colorScheme: ColorScheme
+    let onToggle: () -> Void
+    let onOpen: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 54, height: 54)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                        )
+                    Image(systemName: tool.iconName)
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.white)
+                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+                }
+
+                Spacer()
+
+                Button(action: onToggle) {
+                    Image(systemName: isFavorite ? "heart.fill" : "heart")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(isFavorite ? accent : primary.opacity(0.6))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text(tool.title)
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .foregroundStyle(primary)
+                .lineLimit(1)
+
+            Text(tool.subtitle)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.65))
+                .lineLimit(2)
+
+            Spacer(minLength: 4)
+
+            Button {
+                HapticsManager.shared.pulse()
+                onOpen()
+            } label: {
+                Label("Launch", systemImage: "arrow.up.right.circle.fill")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .labelStyle(.titleAndIcon)
+                    .foregroundStyle(accent)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(18)
+        .frame(width: 220, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .appShadow(colorScheme: colorScheme, level: .medium)
+    }
+}
+
+private struct ToolHistoryRow: View {
+    let tool: ToolItem
+    let primary: Color
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 52, height: 52)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                )
+                .overlay(
+                    Image(systemName: tool.iconName)
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.white)
+                )
+                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tool.title)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text(tool.subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.65))
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(primary.opacity(0.4))
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .appShadow(colorScheme: colorScheme, level: .small)
+    }
+}
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var trigger = false
+        let tools = ToolItem.all
+        var body: some View {
+            HomeDashboardView(
+                tools: tools,
+                favoriteTools: tools,
+                recentTools: tools,
+                newsItems: [
+                    AppNewsItem(title: "Audio extractor gets waveform preview", description: "Drop a clip and preview the waveform before exporting to tune settings faster.", date: .now)
+                ],
+                scrollToTopTrigger: $trigger,
+                accent: .purple,
+                primary: .black,
+                colorScheme: .light,
+                onOpenTool: { _ in },
+                onToggleFavorite: { _ in },
+                onShowTools: {}
+            )
+        }
+    }
+    return PreviewWrapper()
+}

--- a/Resonans/Views/OnboardingView.swift
+++ b/Resonans/Views/OnboardingView.swift
@@ -1,0 +1,363 @@
+import SwiftUI
+
+struct OnboardingFlowView: View {
+    enum WorkflowOption: String, CaseIterable, Identifiable {
+        case contentCreator = "Content creator"
+        case lecture = "Lecture notes"
+        case podcast = "Podcast cleanup"
+
+        var id: String { rawValue }
+
+        var description: String {
+            switch self {
+            case .contentCreator:
+                return "Extract audio from your latest shoot and repurpose it for shorts, reels or voiceovers."
+            case .lecture:
+                return "Pull crisp audio from recorded talks to build searchable study notes."
+            case .podcast:
+                return "Split video interviews into clean audio tracks ready for your feed."
+            }
+        }
+    }
+
+    let tools: [ToolItem]
+    let accent: Color
+    let primary: Color
+    let colorScheme: ColorScheme
+    let onComplete: (Set<ToolItem.Identifier>, Bool) -> Void
+
+    @State private var currentStep = 0
+    @State private var selectedFavorites: Set<ToolItem.Identifier>
+    @State private var selectedWorkflow: WorkflowOption = .contentCreator
+    @State private var showTips = true
+
+    init(
+        tools: [ToolItem],
+        accent: Color,
+        primary: Color,
+        colorScheme: ColorScheme,
+        onComplete: @escaping (Set<ToolItem.Identifier>, Bool) -> Void
+    ) {
+        self.tools = tools
+        self.accent = accent
+        self.primary = primary
+        self.colorScheme = colorScheme
+        self.onComplete = onComplete
+        _selectedFavorites = State(initialValue: Set(tools.prefix(1).map { $0.id }))
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [accent.opacity(colorScheme == .dark ? 0.3 : 0.2), AppStyle.background(for: colorScheme)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                header
+
+                TabView(selection: $currentStep) {
+                    introStep.tag(0)
+                    favoritesStep.tag(1)
+                    workflowStep.tag(2)
+                }
+                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                .animation(.easeInOut(duration: 0.3), value: currentStep)
+
+                progressIndicators
+
+                footerButtons
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 36)
+            .padding(.bottom, 32)
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Welcome to Resonans")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text(stepSubtitle)
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+            }
+            Spacer()
+            Button("Skip") {
+                finish()
+            }
+            .font(.system(size: 15, weight: .semibold, design: .rounded))
+            .foregroundStyle(primary.opacity(0.8))
+        }
+    }
+
+    private var introStep: some View {
+        VStack(spacing: 26) {
+            Spacer()
+            ZStack {
+                RoundedRectangle(cornerRadius: 36, style: .continuous)
+                    .fill(primary.opacity(AppStyle.cardFillOpacity))
+                    .frame(height: 240)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 36, style: .continuous)
+                            .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                    )
+                    .appShadow(colorScheme: colorScheme, level: .large)
+
+                VStack(spacing: 18) {
+                    Image(systemName: "waveform.circle.fill")
+                        .font(.system(size: 64, weight: .bold))
+                        .foregroundStyle(accent)
+                    Text("One workspace for every creative routine")
+                        .font(.system(size: 22, weight: .bold, design: .rounded))
+                        .foregroundStyle(primary)
+                        .multilineTextAlignment(.center)
+                    Text("Resonans keeps all of your media tools organised. Pin favourites, pick up where you left off and stay in the loop with app news.")
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.75))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 12)
+                }
+                .padding(.horizontal, 22)
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 18) {
+                Label("Tap the heart icon to favourite tools you love", systemImage: "heart.circle.fill")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(primary.opacity(AppStyle.cardFillOpacity))
+                    .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+                Label("Swipe through onboarding to learn the essentials", systemImage: "hand.draw.fill")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(primary.opacity(AppStyle.cardFillOpacity))
+                    .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+            }
+
+            Spacer()
+        }
+    }
+
+    private var favoritesStep: some View {
+        VStack(spacing: 24) {
+            Text("Choose your go-to tools")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(primary)
+
+            Text("Tap to pin tools you use the most. We'll show them right on the home screen so they’re always ready.")
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.75))
+                .multilineTextAlignment(.center)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 18) {
+                    ForEach(tools) { tool in
+                        FavoriteSelectionCard(
+                            tool: tool,
+                            isSelected: selectedFavorites.contains(tool.id),
+                            accent: accent,
+                            primary: primary,
+                            colorScheme: colorScheme
+                        ) {
+                            if selectedFavorites.contains(tool.id) {
+                                selectedFavorites.remove(tool.id)
+                            } else {
+                                selectedFavorites.insert(tool.id)
+                            }
+                        }
+                    }
+                }
+                .padding(.top, 12)
+            }
+        }
+    }
+
+    private var workflowStep: some View {
+        VStack(spacing: 26) {
+            Text("Plan your first session")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(primary)
+
+            Text("Tell us what you’re working on and we'll highlight the best starting point.")
+                .font(.system(size: 15, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.75))
+                .multilineTextAlignment(.center)
+
+            Picker("Workflow", selection: $selectedWorkflow) {
+                ForEach(WorkflowOption.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            VStack(alignment: .leading, spacing: 18) {
+                Label(selectedWorkflow.rawValue, systemImage: "sparkles")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text(selectedWorkflow.description)
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.75))
+
+                Toggle(isOn: $showTips) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Show guided tips")
+                            .font(.system(size: 16, weight: .semibold, design: .rounded))
+                            .foregroundStyle(primary)
+                        Text("We'll highlight useful gestures and shortcuts while you explore.")
+                            .font(.system(size: 13, weight: .medium, design: .rounded))
+                            .foregroundStyle(primary.opacity(0.6))
+                    }
+                }
+                .toggleStyle(SwitchToggleStyle(tint: accent))
+                .padding(.top, 8)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(primary.opacity(AppStyle.cardFillOpacity))
+            .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+            )
+            .appShadow(colorScheme: colorScheme, level: .medium)
+
+            Spacer()
+        }
+    }
+
+    private var progressIndicators: some View {
+        HStack(spacing: 10) {
+            ForEach(0..<3) { index in
+                Capsule()
+                    .fill(index == currentStep ? accent : primary.opacity(0.25))
+                    .frame(width: index == currentStep ? 42 : 16, height: 6)
+                    .animation(.spring(response: 0.4, dampingFraction: 0.8), value: currentStep)
+            }
+        }
+    }
+
+    private var footerButtons: some View {
+        HStack(spacing: 16) {
+            if currentStep > 0 {
+                Button {
+                    HapticsManager.shared.selection()
+                    currentStep -= 1
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 18)
+                        .background(primary.opacity(AppStyle.cardFillOpacity))
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+
+            Button {
+                HapticsManager.shared.selection()
+                if currentStep < 2 {
+                    currentStep += 1
+                } else {
+                    finish()
+                }
+            } label: {
+                Label(currentStep < 2 ? "Next" : "Let's go", systemImage: currentStep < 2 ? "chevron.right" : "checkmark.circle.fill")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 22)
+                    .background(accent.opacity(colorScheme == .dark ? 0.3 : 0.18))
+                    .clipShape(Capsule())
+                    .foregroundStyle(accent)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var stepSubtitle: String {
+        switch currentStep {
+        case 0: return "Swipe to explore the essentials"
+        case 1: return "Pick your favourites to pin on Home"
+        default: return "Get personalised tips before you start"
+        }
+    }
+
+    private func finish() {
+        let favorites = selectedFavorites.isEmpty ? Set(tools.prefix(1).map { $0.id }) : selectedFavorites
+        onComplete(favorites, showTips)
+    }
+}
+
+private struct FavoriteSelectionCard: View {
+    let tool: ToolItem
+    let isSelected: Bool
+    let accent: Color
+    let primary: Color
+    let colorScheme: ColorScheme
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                            .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                            .frame(width: 54, height: 54)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                            )
+                        Image(systemName: tool.iconName)
+                            .font(.system(size: 24, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(isSelected ? accent : primary.opacity(0.35))
+                }
+
+                Text(tool.title)
+                    .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text(tool.subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                    .fill(primary.opacity(AppStyle.cardFillOpacity))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                            .stroke(primary.opacity(isSelected ? 0.35 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
+                    )
+            )
+            .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.35)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    OnboardingFlowView(
+        tools: ToolItem.all,
+        accent: Color.purple,
+        primary: .black,
+        colorScheme: .light
+    ) { _, _ in }
+}

--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -1,0 +1,268 @@
+import SwiftUI
+
+struct AudioExtractorView: View {
+    @State private var videoURL: URL?
+    @State private var showPhotoPicker = false
+    @State private var showFilePicker = false
+    @State private var showSourceOptions = false
+    @State private var showConversionSheet = false
+
+    @State private var recents: [RecentItem] = []
+    @State private var showAllRecents = false
+
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
+
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+    private var background: Color { AppStyle.background(for: colorScheme) }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 24) {
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .padding(.bottom, -24)
+                        .id("top")
+
+                    ZStack {
+                        if showSourceOptions {
+                            background.opacity(0.001)
+                                .onTapGesture {
+                                    HapticsManager.shared.pulse()
+                                    withAnimation(.easeInOut(duration: 0.35)) {
+                                        showSourceOptions = false
+                                    }
+                                }
+                        }
+
+                        VStack(spacing: 18) {
+                            sourceSelectionCard
+
+                            if showSourceOptions {
+                                sourceOptionRow
+                                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                            }
+                        }
+                    }
+                    .padding(.horizontal, AppStyle.horizontalPadding)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: showSourceOptions ? 230 : 190)
+
+                    recentSection
+
+                    Spacer(minLength: 40)
+                }
+            }
+            .contentShape(Rectangle())
+            .onChange(of: showSourceOptions) { _, isPresented in
+                if !isPresented {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo("top", anchor: .top)
+                    }
+                }
+            }
+        }
+        .background(
+            LinearGradient(
+                colors: [accent.gradient.opacity(0.2), background],
+                startPoint: .topLeading,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
+        .sheet(isPresented: $showPhotoPicker) {
+            VideoPicker { url in
+                videoURL = url
+                showConversionSheet = true
+            }
+        }
+        .sheet(isPresented: $showFilePicker) {
+            FilePicker { url in
+                videoURL = url
+                showConversionSheet = true
+            }
+        }
+        .sheet(
+            isPresented: $showConversionSheet,
+            onDismiss: { videoURL = nil }
+        ) {
+            if let url = videoURL {
+                ConversionSettingsView(videoURL: url)
+            }
+        }
+    }
+
+    private var sourceSelectionCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Audio Extractor")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                    Text("Ready when you are")
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                        .foregroundStyle(primary)
+                }
+                Spacer()
+                Image(systemName: "waveform")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(accent.color)
+            }
+
+            Spacer()
+
+            VStack(spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                        .fill(primary.opacity(AppStyle.iconFillOpacity))
+                        .frame(width: 84, height: 84)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                                .stroke(primary.opacity(AppStyle.iconStrokeOpacity), lineWidth: 1)
+                        )
+                        .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.4)
+
+                    Image(systemName: "plus")
+                        .font(.system(size: 36, weight: .bold))
+                        .foregroundStyle(primary)
+                }
+
+                Text("Click to add files")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+
+                Text("Choose a video from Files or your photo library.")
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.65))
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+
+            Spacer(minLength: 0)
+        }
+        .padding(AppStyle.innerPadding)
+        .frame(maxWidth: .infinity, minHeight: 190)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .contentShape(Rectangle())
+        .appShadow(colorScheme: colorScheme, level: .large)
+        .scaleEffect(showSourceOptions ? 0.92 : 1)
+        .animation(.spring(response: 0.45, dampingFraction: 0.7), value: showSourceOptions)
+        .onTapGesture {
+            HapticsManager.shared.pulse()
+            withAnimation(.easeInOut(duration: 0.35)) {
+                showSourceOptions.toggle()
+            }
+        }
+    }
+
+    private var sourceOptionRow: some View {
+        HStack(spacing: 16) {
+            sourceOptionCard(icon: "doc.fill", title: "Import from Files") {
+                showFilePicker = true
+                showSourceOptions = false
+            }
+
+            sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Photos") {
+                showPhotoPicker = true
+                showSourceOptions = false
+            }
+        }
+        .transition(.scale(scale: 0.85).combined(with: .opacity))
+    }
+
+    private func sourceOptionCard(icon: String, title: String, action: @escaping () -> Void) -> some View {
+        Button {
+            HapticsManager.shared.pulse()
+            withAnimation(.easeInOut(duration: 0.3)) {
+                action()
+            }
+        } label: {
+            VStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(primary)
+                Text(title)
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .background(
+                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                    .fill(primary.opacity(AppStyle.cardFillOpacity))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                            .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                    )
+            )
+            .appShadow(colorScheme: colorScheme, level: .medium)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Recent conversions")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(primary)
+                .padding(.top, 16)
+                .padding(.horizontal, AppStyle.innerPadding)
+
+            VStack(spacing: 12) {
+                if recents.isEmpty {
+                    Text("No exports yet")
+                        .font(.system(size: 17, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 40)
+                } else {
+                    ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
+                        RecentRow(item: item)
+                            .padding(.horizontal, 12)
+                    }
+
+                    if recents.count > 3 {
+                        Button {
+                            HapticsManager.shared.pulse()
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                showAllRecents.toggle()
+                            }
+                        } label: {
+                            Text(showAllRecents ? "Show less" : "Show more")
+                                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                .foregroundStyle(primary.opacity(0.75))
+                        }
+                        .padding(.top, 6)
+                    }
+                }
+            }
+            .padding(.top, 12)
+            .padding(.bottom, 18)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .appShadow(colorScheme: colorScheme, level: .medium)
+        .padding(.horizontal, AppStyle.horizontalPadding)
+    }
+}
+
+#Preview {
+    AudioExtractorView()
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -4,49 +4,123 @@ struct ToolsView: View {
     let tools: [ToolItem]
     @Binding var selectedTool: ToolItem.Identifier
     @Binding var scrollToTopTrigger: Bool
+    @Binding var pendingLaunch: ToolItem.Identifier?
 
     let accent: AccentColorOption
     let primary: Color
     let colorScheme: ColorScheme
     let onSelect: (ToolItem, Bool) -> Void
+    let onOpen: (ToolItem) -> Void
+
+    @State private var showTopBorder = false
+    @State private var navigationPath: [ToolItem.Identifier] = []
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 20) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .id("toolsTop")
+        NavigationStack(path: $navigationPath) {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: 22) {
+                        Color.clear
+                            .frame(height: AppStyle.innerPadding)
+                            .id("toolsTop")
 
-                    ForEach(tools) { tool in
-                        ToolCard(
-                            tool: tool,
-                            isSelected: tool.id == selectedTool,
-                            primary: primary,
-                            accent: accent.color,
-                            colorScheme: colorScheme
-                        ) {
-                            let isNewSelection = selectedTool != tool.id
-                            HapticsManager.shared.selection()
-                            if isNewSelection {
-                                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                    selectedTool = tool.id
+                        ForEach(tools) { tool in
+                            ToolCard(
+                                tool: tool,
+                                isSelected: tool.id == selectedTool,
+                                primary: primary,
+                                accent: accent.color,
+                                colorScheme: colorScheme,
+                                onSelect: {
+                                    let isNewSelection = selectedTool != tool.id
+                                    if isNewSelection {
+                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                                            selectedTool = tool.id
+                                        }
+                                    }
+                                    onSelect(tool, isNewSelection)
+                                },
+                                onOpen: {
+                                    launch(tool)
                                 }
-                            }
-                            onSelect(tool, isNewSelection)
+                            )
+                            .background(
+                                GeometryReader { geo -> Color in
+                                    DispatchQueue.main.async {
+                                        let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
+                                        if showTopBorder != shouldShow {
+                                            withAnimation(.easeInOut(duration: 0.2)) {
+                                                showTopBorder = shouldShow
+                                            }
+                                        }
+                                    }
+                                    return Color.clear
+                                }
+                            )
                         }
-                    }
 
-                    Spacer(minLength: 80)
+                        Spacer(minLength: 80)
+                    }
+                    .padding(.horizontal, AppStyle.horizontalPadding)
                 }
-                .padding(.horizontal, AppStyle.horizontalPadding)
-            }
-            .coordinateSpace(name: "toolsScroll")
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    proxy.scrollTo("toolsTop", anchor: .top)
+                .coordinateSpace(name: "toolsScroll")
+                .overlay(alignment: .top) {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.45))
+                        .frame(height: 1)
+                        .opacity(showTopBorder ? 1 : 0)
+                        .animation(.easeInOut(duration: 0.2), value: showTopBorder)
+                }
+                .onChange(of: scrollToTopTrigger) { _, _ in
+                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
+                        proxy.scrollTo("toolsTop", anchor: .top)
+                    }
                 }
             }
+            .navigationDestination(for: ToolItem.Identifier.self) { identifier in
+                if let tool = tools.first(where: { $0.id == identifier }) {
+                    tool.destination()
+                        .navigationTitle(tool.title)
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbarColorScheme(colorScheme, for: .navigationBar)
+                } else {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 36, weight: .bold))
+                            .foregroundStyle(primary.opacity(0.7))
+                        Text("Tool unavailable")
+                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                            .foregroundStyle(primary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(AppStyle.background(for: colorScheme))
+                }
+            }
+            .toolbar(.hidden, for: .navigationBar)
+        }
+        .onChange(of: pendingLaunch) { _, identifier in
+            guard let identifier else { return }
+            guard let tool = tools.first(where: { $0.id == identifier }) else { return }
+            let isNewSelection = selectedTool != identifier
+            if isNewSelection {
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                    selectedTool = identifier
+                }
+            }
+            onSelect(tool, isNewSelection)
+            launch(tool)
+            DispatchQueue.main.async {
+                pendingLaunch = nil
+            }
+        }
+    }
+
+    private func launch(_ tool: ToolItem) {
+        HapticsManager.shared.pulse()
+        onOpen(tool)
+        if navigationPath.last != tool.id {
+            navigationPath.removeAll()
+            navigationPath.append(tool.id)
         }
     }
 }
@@ -57,99 +131,101 @@ private struct ToolCard: View {
     let primary: Color
     let accent: Color
     let colorScheme: ColorScheme
-    let action: () -> Void
+    let onSelect: () -> Void
+    let onOpen: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .center, spacing: 16) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                            .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                            .frame(width: 58, height: 58)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                                    .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-                            )
-                        Image(systemName: tool.iconName)
-                            .font(.system(size: 26, weight: .bold))
-                            .foregroundStyle(Color.white)
-                            .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
-                    }
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(tool.title)
-                            .font(.system(size: 20, weight: .semibold, design: .rounded))
-                            .foregroundStyle(primary)
-                            .appTextShadow(colorScheme: colorScheme)
-
-                        Text(tool.subtitle)
-                            .font(.system(size: 14, weight: .regular, design: .rounded))
-                            .foregroundStyle(primary.opacity(0.7))
-                            .lineLimit(2)
-                    }
-
-                    Spacer()
-
-                    if isSelected {
-                        Label("Selected", systemImage: "checkmark.circle.fill")
-                            .font(.system(size: 14, weight: .semibold, design: .rounded))
-                            .labelStyle(.titleAndIcon)
-                            .foregroundStyle(accent)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(
-                                Capsule()
-                                    .fill(accent.opacity(colorScheme == .dark ? 0.18 : 0.12))
-                                    .overlay(
-                                        Capsule()
-                                            .strokeBorder(accent.opacity(0.3), lineWidth: 1)
-                                    )
-                            )
-                    }
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 16) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 58, height: 58)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+                        )
+                    Image(systemName: tool.iconName)
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundStyle(Color.white)
+                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
                 }
 
-                Divider()
-                    .overlay(primary.opacity(0.08))
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(tool.title)
+                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary)
+                        .appTextShadow(colorScheme: colorScheme)
 
-                Text("Tap to configure and start using \(tool.title.lowercased()).")
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.6))
+                    Text(tool.subtitle)
+                        .font(.system(size: 14, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.72))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+                Button(action: onOpen) {
+                    Image(systemName: "arrow.up.right.circle.fill")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(accent)
+                        .padding(6)
+                }
+                .buttonStyle(.plain)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(AppStyle.innerPadding)
-            .background(
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primary.opacity(AppStyle.cardFillOpacity))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(primary.opacity(isSelected ? 0.28 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
-                    )
-            )
-            .contentShape(Rectangle())
-            .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
-            .overlay(
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .strokeBorder(primary.opacity(isSelected ? 0.38 : 0), lineWidth: 3)
-                    .blur(radius: isSelected ? 0 : 6)
-                    .opacity(isSelected ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.3), value: isSelected)
-            )
+
+            Divider()
+                .overlay(primary.opacity(0.08))
+
+            Text("Tap anywhere to set \(tool.title.lowercased()) as your active workspace.")
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.6))
         }
-        .buttonStyle(.plain)
-        .animation(.spring(response: 0.45, dampingFraction: 0.75), value: isSelected)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(AppStyle.innerPadding)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .strokeBorder(primary.opacity(isSelected ? 0.3 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
+                )
+        )
+        .contentShape(Rectangle())
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
+        .overlay(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .strokeBorder(primary.opacity(isSelected ? 0.35 : 0), lineWidth: 3)
+                .blur(radius: isSelected ? 0 : 6)
+                .opacity(isSelected ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: isSelected)
+        )
+        .onTapGesture {
+            HapticsManager.shared.selection()
+            onSelect()
+        }
     }
 }
 
 #Preview {
-    @State var selected = ToolItem.Identifier.audioExtractor
-    @State var trigger = false
-    return ToolsView(
-        tools: ToolItem.all,
-        selectedTool: $selected,
-        scrollToTopTrigger: $trigger,
-        accent: .purple,
-        primary: .black,
-        colorScheme: .light
-    ) { _, _ in }
+    struct PreviewWrapper: View {
+        @State private var selected = ToolItem.Identifier.audioExtractor
+        @State private var trigger = false
+        @State private var pending: ToolItem.Identifier?
+
+        var body: some View {
+            ToolsView(
+                tools: ToolItem.all,
+                selectedTool: $selected,
+                scrollToTopTrigger: $trigger,
+                pendingLaunch: $pending,
+                accent: .purple,
+                primary: .black,
+                colorScheme: .light,
+                onSelect: { _, _ in },
+                onOpen: { _ in }
+            )
+        }
+    }
+    return PreviewWrapper()
 }


### PR DESCRIPTION
## Summary
- rebuild the home tab into a dashboard with news, favorite tools, and recent activity and remove the extractor UI from the landing screen
- refactor the tools tab with navigation support, modular tool destinations, and an updated audio extractor view that uses a plus button workflow
- add an interactive onboarding flow and supporting models to make expanding the toolset easier

## Testing
- not run (UI-focused changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1bfaf5f0483209f9d25ea654c3f10