### PR TITLE
Revamp home dashboard and tool launcher interactions

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -15,20 +15,9 @@ struct ContentView: View {
     @State private var selectedTool: ToolItem.Identifier = .audioExtractor
     @State private var favoriteToolIDs: Set<ToolItem.Identifier> = [.audioExtractor]
     @State private var recentToolIDs: [ToolItem.Identifier] = []
-    @State private var newsItems: [AppNewsItem] = [
-        AppNewsItem(
-            title: "Interactive onboarding arrives",
-            description: "Learn the essentials of Resonans with a guided tour that adapts to your creative flow.",
-            date: Date()
-        ),
-        AppNewsItem(
-            title: "Audio extractor gets a fresh coat",
-            description: "A new streamlined launcher with quick file access keeps your exports on point.",
-            date: Calendar.current.date(byAdding: .day, value: -5, to: Date()) ?? Date()
-        )
-    ]
-
-    @State private var toolLaunchRequest: ToolItem.Identifier?
+    @State private var activeToolID: ToolItem.Identifier?
+    @State private var isToolViewActive = false
+    @State private var showToolClosePrompt = false
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
@@ -44,6 +33,10 @@ struct ContentView: View {
     private var favoriteTools: [ToolItem] { tools.filter { favoriteToolIDs.contains($0.id) } }
     private var recentTools: [ToolItem] {
         recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
+    }
+    private var activeTool: ToolItem? {
+        guard let activeToolID else { return nil }
+        return tools.first(where: { $0.id == activeToolID })
     }
 
     var body: some View {
@@ -70,30 +63,36 @@ struct ContentView: View {
                     .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
                     .animation(.easeInOut(duration: 0.3), value: selectedTab)
 
+                    if let tool = activeTool, isToolViewActive {
+                        ActiveToolContainer(
+                            tool: tool,
+                            accent: accent.color,
+                            primary: primary,
+                            colorScheme: colorScheme,
+                            onClose: {
+                                closeActiveTool()
+                            }
+                        )
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .zIndex(1)
+                    }
+
                     VStack {
                         Spacer()
-                        ZStack {
-                            LinearGradient(
-                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                                startPoint: .bottom,
-                                endPoint: .top
-                            )
-                            .frame(height: 80)
-                            .ignoresSafeArea(edges: .bottom)
-
-                            HStack {
-                                Spacer()
-                                bottomTabButton(systemName: "house.fill", tab: 0, trigger: $homeScrollTrigger)
-                                Spacer()
-                                bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: 1, trigger: $toolsScrollTrigger)
-                                Spacer()
-                                bottomTabButton(systemName: "gearshape.fill", tab: 2, trigger: $settingsScrollTrigger)
-                                Spacer()
-                            }
-                            .padding(.horizontal, 40)
-                            .padding(.vertical, 12)
-                        }
+                        bottomBar
                     }
+                    .zIndex(2)
+                }
+            }
+            .overlay(alignment: .center) {
+                if showToolClosePrompt {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
+                                showToolClosePrompt = false
+                            }
+                        }
                 }
             }
 
@@ -184,15 +183,12 @@ struct ContentView: View {
     private var homeTab: some View {
         HomeDashboardView(
             tools: tools,
-            favoriteTools: favoriteTools,
             recentTools: recentTools,
-            newsItems: newsItems,
             scrollToTopTrigger: $homeScrollTrigger,
             accent: accent,
             primary: primary,
             colorScheme: colorScheme,
             onOpenTool: { launchTool($0) },
-            onToggleFavorite: { toggleFavorite($0) },
             onShowTools: { selectedTab = 1 }
         )
     }
@@ -201,8 +197,8 @@ struct ContentView: View {
         ToolsView(
             tools: tools,
             selectedTool: $selectedTool,
+            activeTool: $activeToolID,
             scrollToTopTrigger: $toolsScrollTrigger,
-            pendingLaunch: $toolLaunchRequest,
             accent: accent,
             primary: primary,
             colorScheme: colorScheme
@@ -210,13 +206,72 @@ struct ContentView: View {
             let text = isNewSelection ? "\(tool.title) ready." : "\(tool.title) already active."
             presentToast(text, color: accent.color)
         } onOpen: { tool in
-            updateRecents(with: tool.id)
+            launchTool(tool, showToast: false)
+        } onClose: { identifier in
+            if activeToolID == identifier {
+                closeActiveTool()
+            }
+        }
+    }
+
+    private var bottomBar: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [background, background.opacity(0.0)]),
+                startPoint: .bottom,
+                endPoint: .top
+            )
+            .frame(height: 88)
+            .ignoresSafeArea(edges: .bottom)
+
+            HStack(spacing: 28) {
+                Spacer()
+
+                if let tool = activeToolID.flatMap({ id in tools.first(where: { $0.id == id }) }) {
+                    ToolDockIcon(
+                        tool: tool,
+                        isActive: isToolViewActive,
+                        showClose: showToolClosePrompt,
+                        accent: accent.color,
+                        primary: primary,
+                        onActivate: {
+                            activateToolFromDock()
+                        },
+                        onToggleClose: {
+                            withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
+                                showToolClosePrompt.toggle()
+                            }
+                        },
+                        onClose: {
+                            closeActiveTool()
+                        }
+                    )
+                }
+
+                bottomTabButton(systemName: "house.fill", tab: 0, trigger: $homeScrollTrigger)
+                bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: 1, trigger: $toolsScrollTrigger)
+                bottomTabButton(systemName: "gearshape.fill", tab: 2, trigger: $settingsScrollTrigger)
+
+                Spacer()
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 14)
         }
     }
 
     private func bottomTabButton(systemName: String, tab: Int, trigger: Binding<Bool>) -> some View {
         Button(action: {
             HapticsManager.shared.pulse()
+            if showToolClosePrompt {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
+                    showToolClosePrompt = false
+                }
+            }
+            if isToolViewActive {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.75)) {
+                    isToolViewActive = false
+                }
+            }
             if selectedTab == tab {
                 trigger.wrappedValue.toggle()
             } else {
@@ -233,13 +288,53 @@ struct ContentView: View {
         }
     }
 
-    private func launchTool(_ tool: ToolItem) {
-        selectedTool = tool.id
+    private func launchTool(_ tool: ToolItem, showToast: Bool = true) {
+        if selectedTool != tool.id {
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                selectedTool = tool.id
+            }
+        } else {
+            selectedTool = tool.id
+        }
         updateRecents(with: tool.id)
-        presentToast("\(tool.title) ready.", color: accent.color)
-        toolLaunchRequest = tool.id
+
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
+            activeToolID = tool.id
+            isToolViewActive = true
+            showToolClosePrompt = false
+        }
+
         if selectedTab != 1 {
             selectedTab = 1
+        }
+
+        if showToast {
+            presentToast("\(tool.title) ready.", color: accent.color)
+        }
+    }
+
+    private func activateToolFromDock() {
+        guard activeToolID != nil else { return }
+        if selectedTab != 1 {
+            selectedTab = 1
+        }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
+            isToolViewActive = true
+            showToolClosePrompt = false
+        }
+    }
+
+    private func closeActiveTool() {
+        guard activeToolID != nil else { return }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
+            isToolViewActive = false
+            showToolClosePrompt = false
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                activeToolID = nil
+            }
         }
     }
 
@@ -275,6 +370,123 @@ struct ContentView: View {
                 showToast = true
             }
         }
+    }
+}
+
+private struct ActiveToolContainer: View {
+    let tool: ToolItem
+    let accent: Color
+    let primary: Color
+    let colorScheme: ColorScheme
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            tool.destination()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(AppStyle.background(for: colorScheme).ignoresSafeArea())
+
+            Button(action: {
+                HapticsManager.shared.selection()
+                onClose()
+            }) {
+                Image(systemName: "xmark.square.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(accent)
+                    .padding(16)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                            .fill(primary.opacity(AppStyle.cardFillOpacity))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                                    .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                            )
+                    )
+                    .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 28)
+            .padding(.trailing, 24)
+        }
+    }
+}
+
+private struct ToolDockIcon: View {
+    let tool: ToolItem
+    let isActive: Bool
+    let showClose: Bool
+    let accent: Color
+    let primary: Color
+    let onActivate: () -> Void
+    let onToggleClose: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            if showClose {
+                Button(action: {
+                    HapticsManager.shared.selection()
+                    onClose()
+                }) {
+                    iconBackground(color: primary.opacity(AppStyle.cardFillOpacity)) {
+                        Image(systemName: "xmark.square.fill")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(accent)
+                    }
+                }
+                .buttonStyle(.plain)
+                .transition(.scale.combined(with: .opacity))
+            } else if isActive {
+                Button(action: {
+                    HapticsManager.shared.selection()
+                    onToggleClose()
+                }) {
+                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .frame(width: 56, height: 56)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                        )
+                        .overlay(
+                            Image(systemName: tool.iconName)
+                                .font(.system(size: 26, weight: .bold))
+                                .foregroundColor(.white)
+                        )
+                        .shadow(color: Color.black.opacity(0.35), radius: 8, x: 0, y: 4)
+                }
+                .buttonStyle(.plain)
+                .transition(.scale.combined(with: .opacity))
+            } else {
+                Button(action: {
+                    HapticsManager.shared.selection()
+                    onActivate()
+                }) {
+                    iconBackground(color: accent.opacity(0.18)) {
+                        Image(systemName: "arrow.up.right.square.fill")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(accent)
+                    }
+                }
+                .buttonStyle(.plain)
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .frame(width: 58, height: 58)
+        .animation(.spring(response: 0.5, dampingFraction: 0.75), value: showClose)
+        .animation(.spring(response: 0.5, dampingFraction: 0.75), value: isActive)
+    }
+
+    private func iconBackground<Content: View>(color: Color, @ViewBuilder content: () -> Content) -> some View {
+        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+            .fill(color)
+            .frame(width: 56, height: 56)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+            )
+            .overlay(content())
+            .shadow(color: primary.opacity(0.15), radius: 12, x: 0, y: 6)
     }
 }
 

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 struct HomeDashboardView: View {
     let tools: [ToolItem]
-    let favoriteTools: [ToolItem]
     let recentTools: [ToolItem]
-    let newsItems: [AppNewsItem]
     @Binding var scrollToTopTrigger: Bool
 
     let accent: AccentColorOption
@@ -12,7 +10,6 @@ struct HomeDashboardView: View {
     let colorScheme: ColorScheme
 
     let onOpenTool: (ToolItem) -> Void
-    let onToggleFavorite: (ToolItem.Identifier) -> Void
     let onShowTools: () -> Void
 
     @State private var showTopBorder = false
@@ -42,9 +39,7 @@ struct HomeDashboardView: View {
                         )
                         .padding(.horizontal, AppStyle.horizontalPadding)
 
-                    favoritesSection
                     recentsSection
-                    newsSection
 
                     Spacer(minLength: 60)
                 }
@@ -89,95 +84,30 @@ struct HomeDashboardView: View {
                 }
             }
 
-            Text("Pin your favourite workflows, hop into tools in one tap and keep an eye on what's new in Resonans.")
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.7))
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 12) {
-                Button {
-                    HapticsManager.shared.selection()
-                    onShowTools()
-                } label: {
-                    Label("Browse tools", systemImage: "wrench.and.screwdriver")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 18)
-                        .background(accent.color.opacity(colorScheme == .dark ? 0.3 : 0.15))
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(accent.color.opacity(0.4), lineWidth: 1)
-                        )
-                        .foregroundStyle(accent.color)
+            Button {
+                HapticsManager.shared.selection()
+                onShowTools()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "wrench.and.screwdriver")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text("Browse tools")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
                 }
-                .buttonStyle(.plain)
-
-                Button {
-                    HapticsManager.shared.selection()
-                    if let firstFavorite = favoriteTools.first ?? tools.first {
-                        onOpenTool(firstFavorite)
-                    }
-                } label: {
-                    Label("Quick start", systemImage: "play.circle.fill")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 18)
-                        .background(primary.opacity(AppStyle.cardFillOpacity))
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                        )
-                        .foregroundStyle(primary)
-                }
-                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.18))
+                .clipShape(RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                        .stroke(accent.color.opacity(0.4), lineWidth: 1)
+                )
+                .foregroundStyle(accent.color)
             }
+            .buttonStyle(.plain)
         }
         .padding(AppStyle.innerPadding)
         .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
-    }
-
-    private var favoritesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Favorite tools")
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
-                Spacer()
-                if !favoriteTools.isEmpty {
-                    Text("Tap to toggle")
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.55))
-                }
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
-
-            if tools.isEmpty {
-                Text("No tools available yet.")
-                    .font(.system(size: 16, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
-                    .frame(maxWidth: .infinity)
-            } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 14) {
-                        ForEach(tools) { tool in
-                            FavoriteToolChip(
-                                tool: tool,
-                                isFavorite: favoriteTools.contains(where: { $0.id == tool.id }),
-                                primary: primary,
-                                accent: accent.color,
-                                colorScheme: colorScheme,
-                                onToggle: { onToggleFavorite(tool.id) },
-                                onOpen: { onOpenTool(tool) }
-                            )
-                        }
-                    }
-                    .padding(.horizontal, AppStyle.horizontalPadding)
-                    .padding(.vertical, 6)
-                }
-            }
-        }
     }
 
     private var recentsSection: some View {
@@ -224,122 +154,6 @@ struct HomeDashboardView: View {
         }
     }
 
-    private var newsSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("App news")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.horizontal, AppStyle.horizontalPadding)
-
-            VStack(spacing: 16) {
-                if newsItems.isEmpty {
-                    Text("Fresh updates will appear here after our next release.")
-                        .font(.system(size: 15, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.7))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 32)
-                } else {
-                    ForEach(newsItems) { news in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(news.formattedDate.uppercased())
-                                .font(.system(size: 11, weight: .bold, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.45))
-                            Text(news.title)
-                                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                                .foregroundStyle(primary)
-                            Text(news.description)
-                                .font(.system(size: 14, weight: .medium, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.7))
-                        }
-                        .padding(AppStyle.innerPadding)
-                        .background(
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                                )
-                        )
-                        .appShadow(colorScheme: colorScheme, level: .small)
-                    }
-                }
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
-        }
-    }
-}
-
-private struct FavoriteToolChip: View {
-    let tool: ToolItem
-    let isFavorite: Bool
-    let primary: Color
-    let accent: Color
-    let colorScheme: ColorScheme
-    let onToggle: () -> Void
-    let onOpen: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                        .frame(width: 54, height: 54)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                                .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                        )
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(.white)
-                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
-                }
-
-                Spacer()
-
-                Button(action: onToggle) {
-                    Image(systemName: isFavorite ? "heart.fill" : "heart")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(isFavorite ? accent : primary.opacity(0.6))
-                }
-                .buttonStyle(.plain)
-            }
-
-            Text(tool.title)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
-                .lineLimit(1)
-
-            Text(tool.subtitle)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.65))
-                .lineLimit(2)
-
-            Spacer(minLength: 4)
-
-            Button {
-                HapticsManager.shared.pulse()
-                onOpen()
-            } label: {
-                Label("Launch", systemImage: "arrow.up.right.circle.fill")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .labelStyle(.titleAndIcon)
-                    .foregroundStyle(accent)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(18)
-        .frame(width: 220, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .appShadow(colorScheme: colorScheme, level: .medium)
-    }
 }
 
 private struct ToolHistoryRow: View {
@@ -400,17 +214,12 @@ private struct ToolHistoryRow: View {
         var body: some View {
             HomeDashboardView(
                 tools: tools,
-                favoriteTools: tools,
                 recentTools: tools,
-                newsItems: [
-                    AppNewsItem(title: "Audio extractor gets waveform preview", description: "Drop a clip and preview the waveform before exporting to tune settings faster.", date: .now)
-                ],
                 scrollToTopTrigger: $trigger,
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
                 onOpenTool: { _ in },
-                onToggleFavorite: { _ in },
                 onShowTools: {}
             )
         }

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -3,45 +3,44 @@ import SwiftUI
 struct ToolsView: View {
     let tools: [ToolItem]
     @Binding var selectedTool: ToolItem.Identifier
+    @Binding var activeTool: ToolItem.Identifier?
     @Binding var scrollToTopTrigger: Bool
-    @Binding var pendingLaunch: ToolItem.Identifier?
 
     let accent: AccentColorOption
     let primary: Color
     let colorScheme: ColorScheme
     let onSelect: (ToolItem, Bool) -> Void
     let onOpen: (ToolItem) -> Void
+    let onClose: (ToolItem.Identifier) -> Void
 
     @State private var showTopBorder = false
-    @State private var navigationPath: [ToolItem.Identifier] = []
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            ScrollViewReader { proxy in
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 22) {
-                        Color.clear
-                            .frame(height: AppStyle.innerPadding)
-                            .id("toolsTop")
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 22) {
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .id("toolsTop")
 
+                    VStack(spacing: 16) {
                         ForEach(tools) { tool in
-                            ToolCard(
+                            ToolListRow(
                                 tool: tool,
                                 isSelected: tool.id == selectedTool,
+                                isActive: tool.id == activeTool,
                                 primary: primary,
                                 accent: accent.color,
                                 colorScheme: colorScheme,
                                 onSelect: {
-                                    let isNewSelection = selectedTool != tool.id
-                                    if isNewSelection {
-                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                            selectedTool = tool.id
-                                        }
-                                    }
-                                    onSelect(tool, isNewSelection)
+                                    select(tool)
                                 },
                                 onOpen: {
-                                    launch(tool)
+                                    select(tool)
+                                    open(tool)
+                                },
+                                onClose: {
+                                    close(tool)
                                 }
                             )
                             .background(
@@ -58,147 +57,126 @@ struct ToolsView: View {
                                 }
                             )
                         }
+                    }
 
-                        Spacer(minLength: 80)
-                    }
-                    .padding(.horizontal, AppStyle.horizontalPadding)
+                    Spacer(minLength: 80)
                 }
-                .coordinateSpace(name: "toolsScroll")
-                .overlay(alignment: .top) {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.45))
-                        .frame(height: 1)
-                        .opacity(showTopBorder ? 1 : 0)
-                        .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-                }
-                .onChange(of: scrollToTopTrigger) { _, _ in
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                        proxy.scrollTo("toolsTop", anchor: .top)
-                    }
-                }
+                .padding(.horizontal, AppStyle.horizontalPadding)
             }
-            .navigationDestination(for: ToolItem.Identifier.self) { identifier in
-                if let tool = tools.first(where: { $0.id == identifier }) {
-                    tool.destination()
-                        .navigationTitle(tool.title)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbarColorScheme(colorScheme, for: .navigationBar)
-                } else {
-                    VStack(spacing: 16) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 36, weight: .bold))
-                            .foregroundStyle(primary.opacity(0.7))
-                        Text("Tool unavailable")
-                            .font(.system(size: 18, weight: .semibold, design: .rounded))
-                            .foregroundStyle(primary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(AppStyle.background(for: colorScheme))
-                }
+            .coordinateSpace(name: "toolsScroll")
+            .background(AppStyle.background(for: colorScheme).ignoresSafeArea())
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.45))
+                    .frame(height: 1)
+                    .opacity(showTopBorder ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
             }
-            .toolbar(.hidden, for: .navigationBar)
-        }
-        .onChange(of: pendingLaunch) { _, identifier in
-            guard let identifier else { return }
-            guard let tool = tools.first(where: { $0.id == identifier }) else { return }
-            let isNewSelection = selectedTool != identifier
-            if isNewSelection {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    selectedTool = identifier
+            .onChange(of: scrollToTopTrigger) { _, _ in
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
+                    proxy.scrollTo("toolsTop", anchor: .top)
                 }
-            }
-            onSelect(tool, isNewSelection)
-            launch(tool)
-            DispatchQueue.main.async {
-                pendingLaunch = nil
             }
         }
     }
 
-    private func launch(_ tool: ToolItem) {
+    private func select(_ tool: ToolItem) {
+        let isNewSelection = selectedTool != tool.id
+        if isNewSelection {
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                selectedTool = tool.id
+            }
+        }
+        onSelect(tool, isNewSelection)
+    }
+
+    private func open(_ tool: ToolItem) {
         HapticsManager.shared.pulse()
         onOpen(tool)
-        if navigationPath.last != tool.id {
-            navigationPath.removeAll()
-            navigationPath.append(tool.id)
-        }
+    }
+
+    private func close(_ tool: ToolItem) {
+        HapticsManager.shared.selection()
+        onClose(tool.id)
     }
 }
 
-private struct ToolCard: View {
+private struct ToolListRow: View {
     let tool: ToolItem
     let isSelected: Bool
+    let isActive: Bool
     let primary: Color
     let accent: Color
     let colorScheme: ColorScheme
     let onSelect: () -> Void
     let onOpen: () -> Void
+    let onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            HStack(alignment: .top, spacing: 16) {
-                ZStack {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 52, height: 52)
+                .overlay(
                     RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                        .frame(width: 58, height: 58)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-                        )
+                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                )
+                .overlay(
                     Image(systemName: tool.iconName)
-                        .font(.system(size: 26, weight: .bold))
-                        .foregroundStyle(Color.white)
-                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.white)
+                )
+                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tool.title)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                Text(tool.subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.65))
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            HStack(spacing: 12) {
+                if isActive {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark.square.fill")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(accent)
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.scale.combined(with: .opacity))
                 }
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(tool.title)
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                        .appTextShadow(colorScheme: colorScheme)
-
-                    Text(tool.subtitle)
-                        .font(.system(size: 14, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.72))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer()
 
                 Button(action: onOpen) {
-                    Image(systemName: "arrow.up.right.circle.fill")
-                        .font(.system(size: 24, weight: .semibold))
+                    Image(systemName: "arrow.up.right.square.fill")
+                        .font(.system(size: 22, weight: .semibold))
                         .foregroundStyle(accent)
-                        .padding(6)
                 }
                 .buttonStyle(.plain)
             }
-
-            Divider()
-                .overlay(primary.opacity(0.08))
-
-            Text("Tap anywhere to set \(tool.title.lowercased()) as your active workspace.")
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.6))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(AppStyle.innerPadding)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
         .background(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                 .fill(primary.opacity(AppStyle.cardFillOpacity))
                 .overlay(
                     RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(isSelected ? 0.3 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
+                        .stroke(primary.opacity(isSelected ? 0.28 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
                 )
         )
-        .contentShape(Rectangle())
+        .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
         .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .strokeBorder(primary.opacity(isSelected ? 0.35 : 0), lineWidth: 3)
-                .blur(radius: isSelected ? 0 : 6)
-                .opacity(isSelected ? 1 : 0)
-                .animation(.easeInOut(duration: 0.3), value: isSelected)
+                .stroke(primary.opacity(isActive ? 0.35 : 0), lineWidth: 3)
+                .blur(radius: isActive ? 0 : 6)
+                .opacity(isActive ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: isActive)
         )
         .onTapGesture {
             HapticsManager.shared.selection()
@@ -210,20 +188,21 @@ private struct ToolCard: View {
 #Preview {
     struct PreviewWrapper: View {
         @State private var selected = ToolItem.Identifier.audioExtractor
+        @State private var active: ToolItem.Identifier? = .audioExtractor
         @State private var trigger = false
-        @State private var pending: ToolItem.Identifier?
 
         var body: some View {
             ToolsView(
                 tools: ToolItem.all,
                 selectedTool: $selected,
+                activeTool: $active,
                 scrollToTopTrigger: $trigger,
-                pendingLaunch: $pending,
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
                 onSelect: { _, _ in },
-                onOpen: { _ in }
+                onOpen: { _ in },
+                onClose: { _ in }
             )
         }
     }


### PR DESCRIPTION
## Summary
- simplify the home dashboard by dropping the favourites and news sections and widening the hero action
- redesign the tools list to match the recent card style with inline launch and close controls
- add a dedicated full-screen tool presenter with a dynamic dock icon that animates open/close transitions

## Testing
- Not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d404ba1e7083208ea518a82516ff1c