### PR TITLE
Revise home and tools flows

### DIFF
--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -10,7 +10,7 @@ struct ToolItem: Identifiable {
     let subtitle: String
     let iconName: String
     let gradientColors: [Color]
-    let destination: () -> AnyView
+    let destination: (@escaping () -> Void) -> AnyView
 
     static let audioExtractor = ToolItem(
         id: .audioExtractor,
@@ -21,7 +21,7 @@ struct ToolItem: Identifiable {
             Color(red: 0.49, green: 0.33, blue: 0.95),
             Color(red: 0.58, green: 0.41, blue: 0.98)
         ],
-        destination: { AnyView(AudioExtractorView()) }
+        destination: { onClose in AnyView(AudioExtractorView(onClose: onClose)) }
     )
 
     static let all: [ToolItem] = [

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -2,9 +2,7 @@ import SwiftUI
 
 struct HomeDashboardView: View {
     let tools: [ToolItem]
-    let favoriteTools: [ToolItem]
     let recentTools: [ToolItem]
-    let newsItems: [AppNewsItem]
     @Binding var scrollToTopTrigger: Bool
 
     let accent: AccentColorOption
@@ -12,7 +10,6 @@ struct HomeDashboardView: View {
     let colorScheme: ColorScheme
 
     let onOpenTool: (ToolItem) -> Void
-    let onToggleFavorite: (ToolItem.Identifier) -> Void
     let onShowTools: () -> Void
 
     @State private var showTopBorder = false
@@ -42,9 +39,7 @@ struct HomeDashboardView: View {
                         )
                         .padding(.horizontal, AppStyle.horizontalPadding)
 
-                    favoritesSection
                     recentsSection
-                    newsSection
 
                     Spacer(minLength: 60)
                 }
@@ -89,95 +84,30 @@ struct HomeDashboardView: View {
                 }
             }
 
-            Text("Pin your favourite workflows, hop into tools in one tap and keep an eye on what's new in Resonans.")
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.7))
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 12) {
-                Button {
-                    HapticsManager.shared.selection()
-                    onShowTools()
-                } label: {
-                    Label("Browse tools", systemImage: "wrench.and.screwdriver")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 18)
-                        .background(accent.color.opacity(colorScheme == .dark ? 0.3 : 0.15))
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(accent.color.opacity(0.4), lineWidth: 1)
-                        )
-                        .foregroundStyle(accent.color)
+            Button {
+                HapticsManager.shared.selection()
+                onShowTools()
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "wrench.and.screwdriver")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text("Browse tools")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
                 }
-                .buttonStyle(.plain)
-
-                Button {
-                    HapticsManager.shared.selection()
-                    if let firstFavorite = favoriteTools.first ?? tools.first {
-                        onOpenTool(firstFavorite)
-                    }
-                } label: {
-                    Label("Quick start", systemImage: "play.circle.fill")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .padding(.vertical, 12)
-                        .padding(.horizontal, 18)
-                        .background(primary.opacity(AppStyle.cardFillOpacity))
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                        )
-                        .foregroundStyle(primary)
-                }
-                .buttonStyle(.plain)
+                .foregroundStyle(accent.color)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.18))
+                .clipShape(RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                        .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                )
             }
+            .buttonStyle(.plain)
         }
         .padding(AppStyle.innerPadding)
         .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
-    }
-
-    private var favoritesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Favorite tools")
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
-                Spacer()
-                if !favoriteTools.isEmpty {
-                    Text("Tap to toggle")
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.55))
-                }
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
-
-            if tools.isEmpty {
-                Text("No tools available yet.")
-                    .font(.system(size: 16, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
-                    .frame(maxWidth: .infinity)
-            } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 14) {
-                        ForEach(tools) { tool in
-                            FavoriteToolChip(
-                                tool: tool,
-                                isFavorite: favoriteTools.contains(where: { $0.id == tool.id }),
-                                primary: primary,
-                                accent: accent.color,
-                                colorScheme: colorScheme,
-                                onToggle: { onToggleFavorite(tool.id) },
-                                onOpen: { onOpenTool(tool) }
-                            )
-                        }
-                    }
-                    .padding(.horizontal, AppStyle.horizontalPadding)
-                    .padding(.vertical, 6)
-                }
-            }
-        }
     }
 
     private var recentsSection: some View {
@@ -222,123 +152,6 @@ struct HomeDashboardView: View {
                 .padding(.horizontal, AppStyle.horizontalPadding)
             }
         }
-    }
-
-    private var newsSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("App news")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.horizontal, AppStyle.horizontalPadding)
-
-            VStack(spacing: 16) {
-                if newsItems.isEmpty {
-                    Text("Fresh updates will appear here after our next release.")
-                        .font(.system(size: 15, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.7))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 32)
-                } else {
-                    ForEach(newsItems) { news in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(news.formattedDate.uppercased())
-                                .font(.system(size: 11, weight: .bold, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.45))
-                            Text(news.title)
-                                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                                .foregroundStyle(primary)
-                            Text(news.description)
-                                .font(.system(size: 14, weight: .medium, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.7))
-                        }
-                        .padding(AppStyle.innerPadding)
-                        .background(
-                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                                )
-                        )
-                        .appShadow(colorScheme: colorScheme, level: .small)
-                    }
-                }
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
-        }
-    }
-}
-
-private struct FavoriteToolChip: View {
-    let tool: ToolItem
-    let isFavorite: Bool
-    let primary: Color
-    let accent: Color
-    let colorScheme: ColorScheme
-    let onToggle: () -> Void
-    let onOpen: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                        .frame(width: 54, height: 54)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                                .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                        )
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(.white)
-                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
-                }
-
-                Spacer()
-
-                Button(action: onToggle) {
-                    Image(systemName: isFavorite ? "heart.fill" : "heart")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(isFavorite ? accent : primary.opacity(0.6))
-                }
-                .buttonStyle(.plain)
-            }
-
-            Text(tool.title)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
-                .lineLimit(1)
-
-            Text(tool.subtitle)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.65))
-                .lineLimit(2)
-
-            Spacer(minLength: 4)
-
-            Button {
-                HapticsManager.shared.pulse()
-                onOpen()
-            } label: {
-                Label("Launch", systemImage: "arrow.up.right.circle.fill")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .labelStyle(.titleAndIcon)
-                    .foregroundStyle(accent)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(18)
-        .frame(width: 220, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .appShadow(colorScheme: colorScheme, level: .medium)
     }
 }
 
@@ -400,17 +213,12 @@ private struct ToolHistoryRow: View {
         var body: some View {
             HomeDashboardView(
                 tools: tools,
-                favoriteTools: tools,
                 recentTools: tools,
-                newsItems: [
-                    AppNewsItem(title: "Audio extractor gets waveform preview", description: "Drop a clip and preview the waveform before exporting to tune settings faster.", date: .now)
-                ],
                 scrollToTopTrigger: $trigger,
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
                 onOpenTool: { _ in },
-                onToggleFavorite: { _ in },
                 onShowTools: {}
             )
         }

--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct AudioExtractorView: View {
+    let onClose: () -> Void
+
     @State private var videoURL: URL?
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
@@ -16,6 +18,10 @@ struct AudioExtractorView: View {
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
     private var background: Color { AppStyle.background(for: colorScheme) }
     private var primary: Color { AppStyle.primary(for: colorScheme) }
+
+    init(onClose: @escaping () -> Void = {}) {
+        self.onClose = onClose
+    }
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -91,6 +97,9 @@ struct AudioExtractorView: View {
             if let url = videoURL {
                 ConversionSettingsView(videoURL: url)
             }
+        }
+        .overlay(alignment: .topTrailing) {
+            closeButton
         }
     }
 
@@ -177,6 +186,30 @@ struct AudioExtractorView: View {
             }
         }
         .transition(.scale(scale: 0.85).combined(with: .opacity))
+    }
+
+    private var closeButton: some View {
+        Button {
+            HapticsManager.shared.selection()
+            onClose()
+        } label: {
+            Image(systemName: "xmark.square.fill")
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(accent.color)
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                        .fill(primary.opacity(AppStyle.cardFillOpacity))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .padding(.trailing, AppStyle.horizontalPadding)
+        .padding(.top, 10)
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
     }
 
     private func sourceOptionCard(icon: String, title: String, action: @escaping () -> Void) -> some View {

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -4,202 +4,175 @@ struct ToolsView: View {
     let tools: [ToolItem]
     @Binding var selectedTool: ToolItem.Identifier
     @Binding var scrollToTopTrigger: Bool
-    @Binding var pendingLaunch: ToolItem.Identifier?
 
     let accent: AccentColorOption
     let primary: Color
     let colorScheme: ColorScheme
+    let activeTool: ToolItem.Identifier?
     let onSelect: (ToolItem, Bool) -> Void
     let onOpen: (ToolItem) -> Void
+    let onClose: (ToolItem.Identifier) -> Void
 
     @State private var showTopBorder = false
-    @State private var navigationPath: [ToolItem.Identifier] = []
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            ScrollViewReader { proxy in
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 22) {
-                        Color.clear
-                            .frame(height: AppStyle.innerPadding)
-                            .id("toolsTop")
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 18) {
+                    Color.clear
+                        .frame(height: AppStyle.innerPadding)
+                        .id("toolsTop")
 
-                        ForEach(tools) { tool in
-                            ToolCard(
-                                tool: tool,
-                                isSelected: tool.id == selectedTool,
-                                primary: primary,
-                                accent: accent.color,
-                                colorScheme: colorScheme,
-                                onSelect: {
-                                    let isNewSelection = selectedTool != tool.id
-                                    if isNewSelection {
-                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                            selectedTool = tool.id
+                    ForEach(tools) { tool in
+                        ToolListRow(
+                            tool: tool,
+                            primary: primary,
+                            colorScheme: colorScheme,
+                            accent: accent.color,
+                            isSelected: tool.id == selectedTool,
+                            isOpen: activeTool == tool.id,
+                            onSelect: {
+                                let isNewSelection = selectedTool != tool.id
+                                if isNewSelection {
+                                    withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+                                        selectedTool = tool.id
+                                    }
+                                }
+                                onSelect(tool, isNewSelection)
+                            },
+                            onOpen: {
+                                HapticsManager.shared.pulse()
+                                onOpen(tool)
+                            },
+                            onClose: {
+                                HapticsManager.shared.pulse()
+                                onClose(tool.id)
+                            }
+                        )
+                        .background(
+                            GeometryReader { geo -> Color in
+                                DispatchQueue.main.async {
+                                    let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
+                                    if showTopBorder != shouldShow {
+                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                            showTopBorder = shouldShow
                                         }
                                     }
-                                    onSelect(tool, isNewSelection)
-                                },
-                                onOpen: {
-                                    launch(tool)
                                 }
-                            )
-                            .background(
-                                GeometryReader { geo -> Color in
-                                    DispatchQueue.main.async {
-                                        let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
-                                        if showTopBorder != shouldShow {
-                                            withAnimation(.easeInOut(duration: 0.2)) {
-                                                showTopBorder = shouldShow
-                                            }
-                                        }
-                                    }
-                                    return Color.clear
-                                }
-                            )
-                        }
+                                return Color.clear
+                            }
+                        )
+                    }
 
-                        Spacer(minLength: 80)
-                    }
-                    .padding(.horizontal, AppStyle.horizontalPadding)
+                    Spacer(minLength: 80)
                 }
-                .coordinateSpace(name: "toolsScroll")
-                .overlay(alignment: .top) {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.45))
-                        .frame(height: 1)
-                        .opacity(showTopBorder ? 1 : 0)
-                        .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-                }
-                .onChange(of: scrollToTopTrigger) { _, _ in
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                        proxy.scrollTo("toolsTop", anchor: .top)
-                    }
-                }
+                .padding(.horizontal, AppStyle.horizontalPadding)
             }
-            .navigationDestination(for: ToolItem.Identifier.self) { identifier in
-                if let tool = tools.first(where: { $0.id == identifier }) {
-                    tool.destination()
-                        .navigationTitle(tool.title)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbarColorScheme(colorScheme, for: .navigationBar)
-                } else {
-                    VStack(spacing: 16) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 36, weight: .bold))
-                            .foregroundStyle(primary.opacity(0.7))
-                        Text("Tool unavailable")
-                            .font(.system(size: 18, weight: .semibold, design: .rounded))
-                            .foregroundStyle(primary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(AppStyle.background(for: colorScheme))
-                }
+            .coordinateSpace(name: "toolsScroll")
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.45))
+                    .frame(height: 1)
+                    .opacity(showTopBorder ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
             }
-            .toolbar(.hidden, for: .navigationBar)
-        }
-        .onChange(of: pendingLaunch) { _, identifier in
-            guard let identifier else { return }
-            guard let tool = tools.first(where: { $0.id == identifier }) else { return }
-            let isNewSelection = selectedTool != identifier
-            if isNewSelection {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    selectedTool = identifier
+            .onChange(of: scrollToTopTrigger) { _, _ in
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
+                    proxy.scrollTo("toolsTop", anchor: .top)
                 }
-            }
-            onSelect(tool, isNewSelection)
-            launch(tool)
-            DispatchQueue.main.async {
-                pendingLaunch = nil
             }
         }
-    }
-
-    private func launch(_ tool: ToolItem) {
-        HapticsManager.shared.pulse()
-        onOpen(tool)
-        if navigationPath.last != tool.id {
-            navigationPath.removeAll()
-            navigationPath.append(tool.id)
-        }
+        .background(AppStyle.background(for: colorScheme))
     }
 }
 
-private struct ToolCard: View {
+private struct ToolListRow: View {
     let tool: ToolItem
-    let isSelected: Bool
     let primary: Color
-    let accent: Color
     let colorScheme: ColorScheme
+    let accent: Color
+    let isSelected: Bool
+    let isOpen: Bool
     let onSelect: () -> Void
     let onOpen: () -> Void
+    let onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            HStack(alignment: .top, spacing: 16) {
-                ZStack {
+        HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                .frame(width: 52, height: 52)
+                .overlay(
                     RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                        .frame(width: 58, height: 58)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-                        )
+                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                )
+                .overlay(
                     Image(systemName: tool.iconName)
-                        .font(.system(size: 26, weight: .bold))
+                        .font(.system(size: 24, weight: .bold))
                         .foregroundStyle(Color.white)
-                        .shadow(color: Color.black.opacity(0.35), radius: 6, x: 0, y: 2)
-                }
+                )
+                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
-                VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(tool.title)
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
                         .foregroundStyle(primary)
-                        .appTextShadow(colorScheme: colorScheme)
-
-                    Text(tool.subtitle)
-                        .font(.system(size: 14, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.72))
-                        .fixedSize(horizontal: false, vertical: true)
+                    if isOpen {
+                        Text("OPEN")
+                            .font(.system(size: 12, weight: .bold, design: .rounded))
+                            .foregroundStyle(accent)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                Capsule()
+                                    .fill(accent.opacity(0.15))
+                            )
+                    }
                 }
 
-                Spacer()
+                Text(tool.subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.65))
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            HStack(spacing: 12) {
+                if isOpen {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark.square.fill")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundStyle(accent)
+                    }
+                    .buttonStyle(.plain)
+                }
 
                 Button(action: onOpen) {
-                    Image(systemName: "arrow.up.right.circle.fill")
-                        .font(.system(size: 24, weight: .semibold))
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.system(size: 22, weight: .semibold))
                         .foregroundStyle(accent)
-                        .padding(6)
                 }
                 .buttonStyle(.plain)
             }
-
-            Divider()
-                .overlay(primary.opacity(0.08))
-
-            Text("Tap anywhere to set \(tool.title.lowercased()) as your active workspace.")
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.6))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(AppStyle.innerPadding)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
         .background(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                 .fill(primary.opacity(AppStyle.cardFillOpacity))
                 .overlay(
                     RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .strokeBorder(primary.opacity(isSelected ? 0.3 : AppStyle.strokeOpacity), lineWidth: isSelected ? 2 : 1)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
                 )
         )
-        .contentShape(Rectangle())
-        .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .strokeBorder(primary.opacity(isSelected ? 0.35 : 0), lineWidth: 3)
-                .blur(radius: isSelected ? 0 : 6)
-                .opacity(isSelected ? 1 : 0)
-                .animation(.easeInOut(duration: 0.3), value: isSelected)
+                .stroke(accent.opacity(isSelected ? 0.45 : 0), lineWidth: isSelected ? 2 : 0)
         )
+        .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
+        .contentShape(Rectangle())
         .onTapGesture {
             HapticsManager.shared.selection()
             onSelect()
@@ -211,19 +184,19 @@ private struct ToolCard: View {
     struct PreviewWrapper: View {
         @State private var selected = ToolItem.Identifier.audioExtractor
         @State private var trigger = false
-        @State private var pending: ToolItem.Identifier?
 
         var body: some View {
             ToolsView(
                 tools: ToolItem.all,
                 selectedTool: $selected,
                 scrollToTopTrigger: $trigger,
-                pendingLaunch: $pending,
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
+                activeTool: nil,
                 onSelect: { _, _ in },
-                onOpen: { _ in }
+                onOpen: { _ in },
+                onClose: { _ in }
             )
         }
     }


### PR DESCRIPTION
## Summary
- streamline the home dashboard by focusing the hero card on browsing tools and keeping only the recent history section
- redesign tool launching so tools open as a dedicated tab with an animated quick-close control in the bottom bar and injected close handlers
- rebuild the tools list to mirror the recent-card style with open/close buttons and provide in-tool close affordances

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d404ba1e7083208ea518a82516ff1c