### PR TITLE
Adjust tool presentation and controls

### DIFF
--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -218,7 +218,7 @@ struct ConversionSettingsView: View {
                                 Button(action: {
                                     withAnimation { showBitrateInfo.toggle() }
                                 }) {
-                                    Image(systemName: "questionmark.circle")
+                                    Image(systemName: "info.circle")
                                         .opacity(0.5)
                                 }
                                 .buttonStyle(.plain)

--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -98,9 +98,6 @@ struct AudioExtractorView: View {
                 ConversionSettingsView(videoURL: url)
             }
         }
-        .overlay(alignment: .topTrailing) {
-            closeButton
-        }
     }
 
     private var sourceSelectionCard: some View {
@@ -186,30 +183,6 @@ struct AudioExtractorView: View {
             }
         }
         .transition(.scale(scale: 0.85).combined(with: .opacity))
-    }
-
-    private var closeButton: some View {
-        Button {
-            HapticsManager.shared.selection()
-            onClose()
-        } label: {
-            Image(systemName: "xmark.square.fill")
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(accent.color)
-                .padding(12)
-                .background(
-                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
-                        .fill(primary.opacity(AppStyle.cardFillOpacity))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
-                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                        )
-                )
-        }
-        .buttonStyle(.plain)
-        .padding(.trailing, AppStyle.horizontalPadding)
-        .padding(.top, 10)
-        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
     }
 
     private func sourceOptionCard(icon: String, title: String, action: @escaping () -> Void) -> some View {

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -82,7 +82,14 @@ struct ToolsView: View {
                 }
             }
         }
-        .background(AppStyle.background(for: colorScheme))
+        .background(
+            LinearGradient(
+                colors: [accent.gradient.opacity(0.2), AppStyle.background(for: colorScheme)],
+                startPoint: .topLeading,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
     }
 }
 
@@ -118,17 +125,6 @@ private struct ToolListRow: View {
                     Text(tool.title)
                         .font(.system(size: 18, weight: .semibold, design: .rounded))
                         .foregroundStyle(primary)
-                    if isOpen {
-                        Text("OPEN")
-                            .font(.system(size: 12, weight: .bold, design: .rounded))
-                            .foregroundStyle(accent)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(
-                                Capsule()
-                                    .fill(accent.opacity(0.15))
-                            )
-                    }
                 }
 
                 Text(tool.subtitle)
@@ -139,23 +135,20 @@ private struct ToolListRow: View {
 
             Spacer()
 
-            HStack(spacing: 12) {
+            Button(action: {
+                HapticsManager.shared.pulse()
                 if isOpen {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark.square.fill")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundStyle(accent)
-                    }
-                    .buttonStyle(.plain)
+                    onClose()
+                } else {
+                    onOpen()
                 }
-
-                Button(action: onOpen) {
-                    Image(systemName: "arrow.up.right.square")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(accent)
-                }
-                .buttonStyle(.plain)
+            }) {
+                Image(systemName: isOpen ? "xmark" : "chevron.right")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(accent)
+                    .padding(.horizontal, 4)
             }
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 16)
@@ -169,9 +162,16 @@ private struct ToolListRow: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(accent.opacity(isSelected ? 0.45 : 0), lineWidth: isSelected ? 2 : 0)
+                .stroke(
+                    accent.opacity(isOpen ? 0.65 : isSelected ? 0.4 : 0),
+                    lineWidth: isOpen ? 3 : isSelected ? 2 : 0
+                )
         )
-        .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
+        .appShadow(
+            colorScheme: colorScheme,
+            level: .medium,
+            opacity: isOpen ? 0.6 : (isSelected ? 0.5 : 0.4)
+        )
         .contentShape(Rectangle())
         .onTapGesture {
             HapticsManager.shared.selection()


### PR DESCRIPTION
## Summary
- update the main header and bottom toolbar to better handle active tools
- refresh the tools list styling with gradient background and inline open/close affordances
- remove the in-tool close button and replace stray question mark affordances outside Settings

## Testing
- not run (iOS project; Xcode tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d41b7522548320b99995361f5ccb2a