### PR TITLE
Adjust tool presentation and controls

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -84,12 +84,12 @@ struct ContentView: View {
                             HStack {
                                 Spacer()
                                 HStack(spacing: 32) {
+                                    bottomTabButton(systemName: "house.fill", tab: .home, trigger: $homeScrollTrigger)
+                                    bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: .tools, trigger: $toolsScrollTrigger)
                                     if let activeToolID {
                                         toolIconButton(for: activeToolID)
                                             .transition(.scale.combined(with: .opacity))
                                     }
-                                    bottomTabButton(systemName: "house.fill", tab: .home, trigger: $homeScrollTrigger)
-                                    bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: .tools, trigger: $toolsScrollTrigger)
                                     bottomTabButton(systemName: "gearshape.fill", tab: .settings, trigger: $settingsScrollTrigger)
                                 }
                                 .padding(.horizontal, 8)
@@ -190,9 +190,8 @@ struct ContentView: View {
                     .opacity(selectedTab == .tools ? 1 : 0)
                 Text("Settings")
                     .opacity(selectedTab == .settings ? 1 : 0)
-                if case let .tool(identifier) = selectedTab,
-                   let tool = tools.first(where: { $0.id == identifier }) {
-                    Text(tool.title)
+                if case .tool = selectedTab {
+                    Text("Tool")
                         .opacity(1)
                 }
             }
@@ -205,6 +204,25 @@ struct ContentView: View {
 
             Spacer()
 
+            headerActionButton
+        }
+    }
+
+    @ViewBuilder
+    private var headerActionButton: some View {
+        if activeToolID != nil {
+            Button(action: {
+                HapticsManager.shared.selection()
+                closeActiveTool()
+            }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(primary)
+                    .appTextShadow(colorScheme: colorScheme)
+            }
+            .buttonStyle(.plain)
+            .padding(.trailing, 22)
+        } else if selectedTab == .settings {
             Button(action: {
                 HapticsManager.shared.pulse()
                 showOnboarding = true
@@ -291,8 +309,6 @@ struct ContentView: View {
         } else {
             isSelected = false
         }
-        let isActive = activeToolID == identifier
-
         return ZStack {
             Button {
                 HapticsManager.shared.pulse()
@@ -313,7 +329,7 @@ struct ContentView: View {
             } label: {
                 Image(systemName: "arrow.up.right.square.fill")
                     .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(isActive ? accent.color : primary.opacity(0.5))
+                    .foregroundStyle(isSelected ? accent.color : primary.opacity(0.5))
             }
             .buttonStyle(.plain)
             .scaleEffect(showToolCloseIcon && isSelected ? 0.01 : 1)

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -218,7 +218,7 @@ struct ConversionSettingsView: View {
                                 Button(action: {
                                     withAnimation { showBitrateInfo.toggle() }
                                 }) {
-                                    Image(systemName: "questionmark.circle")
+                                    Image(systemName: "info.circle")
                                         .opacity(0.5)
                                 }
                                 .buttonStyle(.plain)

--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -98,9 +98,6 @@ struct AudioExtractorView: View {
                 ConversionSettingsView(videoURL: url)
             }
         }
-        .overlay(alignment: .topTrailing) {
-            closeButton
-        }
     }
 
     private var sourceSelectionCard: some View {
@@ -186,30 +183,6 @@ struct AudioExtractorView: View {
             }
         }
         .transition(.scale(scale: 0.85).combined(with: .opacity))
-    }
-
-    private var closeButton: some View {
-        Button {
-            HapticsManager.shared.selection()
-            onClose()
-        } label: {
-            Image(systemName: "xmark.square.fill")
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(accent.color)
-                .padding(12)
-                .background(
-                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
-                        .fill(primary.opacity(AppStyle.cardFillOpacity))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
-                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                        )
-                )
-        }
-        .buttonStyle(.plain)
-        .padding(.trailing, AppStyle.horizontalPadding)
-        .padding(.top, 10)
-        .appShadow(colorScheme: colorScheme, level: .medium, opacity: 0.35)
     }
 
     private func sourceOptionCard(icon: String, title: String, action: @escaping () -> Void) -> some View {

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -16,8 +16,10 @@ struct ToolsView: View {
     @State private var showTopBorder = false
 
     var body: some View {
+        let backgroundColor = AppStyle.background(for: colorScheme)
+
         ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
+            ScrollView(.vertical) {
                 VStack(spacing: 18) {
                     Color.clear
                         .frame(height: AppStyle.innerPadding)
@@ -82,7 +84,14 @@ struct ToolsView: View {
                 }
             }
         }
-        .background(AppStyle.background(for: colorScheme))
+        .background(
+            LinearGradient(
+                colors: [accent.gradient.opacity(0.4), backgroundColor],
+                startPoint: .topLeading,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
     }
 }
 
@@ -114,22 +123,9 @@ private struct ToolListRow: View {
                 .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(tool.title)
-                        .font(.system(size: 18, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary)
-                    if isOpen {
-                        Text("OPEN")
-                            .font(.system(size: 12, weight: .bold, design: .rounded))
-                            .foregroundStyle(accent)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(
-                                Capsule()
-                                    .fill(accent.opacity(0.15))
-                            )
-                    }
-                }
+                Text(tool.title)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
 
                 Text(tool.subtitle)
                     .font(.system(size: 13, weight: .medium, design: .rounded))
@@ -139,23 +135,18 @@ private struct ToolListRow: View {
 
             Spacer()
 
-            HStack(spacing: 12) {
+            Button(action: {
                 if isOpen {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark.square.fill")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundStyle(accent)
-                    }
-                    .buttonStyle(.plain)
+                    onClose()
+                } else {
+                    onOpen()
                 }
-
-                Button(action: onOpen) {
-                    Image(systemName: "arrow.up.right.square")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(accent)
-                }
-                .buttonStyle(.plain)
+            }) {
+                Image(systemName: isOpen ? "xmark" : "chevron.right")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(accent)
             }
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 16)
@@ -169,9 +160,16 @@ private struct ToolListRow: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(accent.opacity(isSelected ? 0.45 : 0), lineWidth: isSelected ? 2 : 0)
+                .stroke(
+                    accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
+                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
+                )
         )
-        .appShadow(colorScheme: colorScheme, level: .medium, opacity: isSelected ? 0.55 : 0.4)
+        .appShadow(
+            colorScheme: colorScheme,
+            level: .medium,
+            opacity: (isOpen || isSelected) ? 0.6 : 0.4
+        )
         .contentShape(Rectangle())
         .onTapGesture {
             HapticsManager.shared.selection()


### PR DESCRIPTION
## Summary
- update Tools view styling with a gradient backdrop and simplified row controls that highlight active tools
- move the active tool shortcut beside the Tools tab and only accent it when the tool view is visible
- replace question mark affordances with contextual close controls, showing "Tool" in the header when a tool is open and removing the in-tool close button

## Testing
- Not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d41b7522548320b99995361f5ccb2a