### PR TITLE
Revamp extractor UI and persist tool history

### DIFF
--- a/Resonans/CacheManager.swift
+++ b/Resonans/CacheManager.swift
@@ -7,5 +7,70 @@ final class CacheManager {
     /// Clears any cached network responses.
     func clear() {
         URLCache.shared.removeAllCachedResponses()
+        CacheFile.allCases.forEach { file in
+            if let url = cacheURL(for: file) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
+    private enum CacheFile: String, CaseIterable {
+        case recentTools = "recent_tools.json"
+        case audioRecents = "audio_recents.json"
+    }
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private func cacheURL(for file: CacheFile) -> URL? {
+        guard let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return cachesDirectory.appendingPathComponent(file.rawValue)
+    }
+
+    func loadRecentTools() -> [ToolItem.Identifier] {
+        guard
+            let url = cacheURL(for: .recentTools),
+            let data = try? Data(contentsOf: url),
+            let rawValues = try? decoder.decode([String].self, from: data)
+        else {
+            return []
+        }
+
+        return rawValues.compactMap { ToolItem.Identifier(rawValue: $0) }
+    }
+
+    func saveRecentTools(_ identifiers: [ToolItem.Identifier]) {
+        guard let url = cacheURL(for: .recentTools) else { return }
+        let rawValues = identifiers.map { $0.rawValue }
+        guard let data = try? encoder.encode(rawValues) else { return }
+        try? data.write(to: url, options: [.atomic])
+    }
+
+    func loadRecentConversions() -> [RecentItem] {
+        guard
+            let url = cacheURL(for: .audioRecents),
+            let data = try? Data(contentsOf: url),
+            let items = try? decoder.decode([RecentItem].self, from: data)
+        else {
+            return []
+        }
+        return items
+    }
+
+    func saveRecentConversions(_ items: [RecentItem]) {
+        guard let url = cacheURL(for: .audioRecents) else { return }
+        guard let data = try? encoder.encode(items) else { return }
+        try? data.write(to: url, options: [.atomic])
     }
 }

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RecentRow: View {
     let item: RecentItem
+    let onExport: (RecentItem) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     private var primary: Color { AppStyle.primary(for: colorScheme) }
@@ -28,14 +29,14 @@ struct RecentRow: View {
                     .foregroundStyle(primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Text(item.duration)
+                Text(item.formattedDuration)
                     .font(.system(size: 14, weight: .regular))
                     .foregroundStyle(primary.opacity(0.8))
             }
             Spacer()
             Button(action: {
                 HapticsManager.shared.pulse()
-                /* TODO: share/download */
+                onExport(item)
             }) {
                 Image(systemName: "square.and.arrow.down")
                     .font(.system(size: 22, weight: .bold))

--- a/Resonans/Models/RecentItem.swift
+++ b/Resonans/Models/RecentItem.swift
@@ -1,8 +1,28 @@
 import Foundation
 
-struct RecentItem: Identifiable {
-    let id = UUID()
+struct RecentItem: Identifiable, Codable {
+    let id: UUID
     let title: String
-    let duration: String
+    let duration: TimeInterval
+    let fileURL: URL
+    let createdAt: Date
+
+    init(id: UUID = UUID(), title: String, duration: TimeInterval, fileURL: URL, createdAt: Date = Date()) {
+        self.id = id
+        self.title = title
+        self.duration = duration
+        self.fileURL = fileURL
+        self.createdAt = createdAt
+    }
+
+    var formattedDuration: String {
+        guard duration.isFinite, duration > 0 else {
+            return "Unknown length"
+        }
+        let totalSeconds = Int(duration.rounded())
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
 }
 

--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ToolItem: Identifiable {
-    enum Identifier: String, Hashable {
+    enum Identifier: String, Hashable, Codable {
         case audioExtractor
     }
 
@@ -14,7 +14,7 @@ struct ToolItem: Identifiable {
 
     static let audioExtractor = ToolItem(
         id: .audioExtractor,
-        title: "Audio Extractor",
+        title: "Extractor",
         subtitle: "Pull crisp audio tracks from your videos in seconds.",
         iconName: "waveform.circle.fill",
         gradientColors: [

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 struct ConversionSettingsView: View {
     let videoURL: URL
+    let onConversionComplete: ((URL, TimeInterval) -> Void)?
     @Environment(\.dismiss) private var dismiss
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
@@ -38,6 +39,11 @@ struct ConversionSettingsView: View {
 
     private var clampedProgress: Double {
         min(max(progressValue, 0), 1)
+    }
+
+    init(videoURL: URL, onConversionComplete: ((URL, TimeInterval) -> Void)? = nil) {
+        self.videoURL = videoURL
+        self.onConversionComplete = onConversionComplete
     }
 
     var body: some View {
@@ -444,6 +450,7 @@ struct ConversionSettingsView: View {
                     exportURL = url
                     HapticsManager.shared.notify(.success)
                     showSuccessSheet = true
+                    onConversionComplete?(url, audioDuration)
                 case .failure:
                     dismiss()
                 }

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -9,7 +9,6 @@ struct ToolsView: View {
     let primary: Color
     let colorScheme: ColorScheme
     let activeTool: ToolItem.Identifier?
-    let onSelect: (ToolItem, Bool) -> Void
     let onOpen: (ToolItem) -> Void
     let onClose: (ToolItem.Identifier) -> Void
 
@@ -33,22 +32,20 @@ struct ToolsView: View {
                             accent: accent.color,
                             isSelected: tool.id == selectedTool,
                             isOpen: activeTool == tool.id,
-                            onSelect: {
-                                let isNewSelection = selectedTool != tool.id
-                                if isNewSelection {
+                            onToggle: {
+                                let shouldOpen = activeTool != tool.id
+                                if selectedTool != tool.id {
                                     withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
                                         selectedTool = tool.id
                                     }
                                 }
-                                onSelect(tool, isNewSelection)
-                            },
-                            onOpen: {
-                                HapticsManager.shared.pulse()
-                                onOpen(tool)
-                            },
-                            onClose: {
-                                HapticsManager.shared.pulse()
-                                onClose(tool.id)
+                                if shouldOpen {
+                                    HapticsManager.shared.pulse()
+                                    onOpen(tool)
+                                } else {
+                                    HapticsManager.shared.pulse()
+                                    onClose(tool.id)
+                                }
                             }
                         )
                         .background(
@@ -97,9 +94,7 @@ private struct ToolListRow: View {
     let accent: Color
     let isSelected: Bool
     let isOpen: Bool
-    let onSelect: () -> Void
-    let onOpen: () -> Void
-    let onClose: () -> Void
+    let onToggle: () -> Void
 
     var body: some View {
         HStack(spacing: 16) {
@@ -130,13 +125,7 @@ private struct ToolListRow: View {
 
             Spacer()
 
-            Button(action: {
-                if isOpen {
-                    onClose()
-                } else {
-                    onOpen()
-                }
-            }) {
+            Button(action: onToggle) {
                 Image(systemName: isOpen ? "xmark" : "chevron.right")
                     .font(.system(size: 24, weight: .semibold))
                     .foregroundStyle(accent)
@@ -166,10 +155,7 @@ private struct ToolListRow: View {
             opacity: (isOpen || isSelected) ? 0.6 : 0.4
         )
         .contentShape(Rectangle())
-        .onTapGesture {
-            HapticsManager.shared.selection()
-            onSelect()
-        }
+        .onTapGesture(perform: onToggle)
     }
 }
 
@@ -187,7 +173,6 @@ private struct ToolListRow: View {
                 primary: .black,
                 colorScheme: .light,
                 activeTool: nil,
-                onSelect: { _, _ in },
                 onOpen: { _ in },
                 onClose: { _ in }
             )


### PR DESCRIPTION
## Summary
- remove transient toast messaging, align navigation header spacing, and ensure the optional tool tab sits between tools and settings
- persist recent tool selections via CacheManager and load them on launch so the dashboard history survives restarts
- redesign the extractor surface with permanent file/library buttons, rename it to "Extractor", and store recent conversions for re-export via the updated cache utilities

## Testing
- xcodebuild -project Resonans.xcodeproj -scheme Resonans -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d42249d9ec83209e79e431c8e68c67