### PR TITLE
Refine extractor workflow and persistence

### DIFF
--- a/Resonans/CacheManager.swift
+++ b/Resonans/CacheManager.swift
@@ -2,10 +2,136 @@ import Foundation
 
 final class CacheManager {
     static let shared = CacheManager()
-    private init() {}
 
-    /// Clears any cached network responses.
+    private let fileManager = FileManager.default
+    private let baseDirectory: URL
+    private let exportsDirectory: URL
+    private let recentToolsURL: URL
+    private let recentConversionsURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private let maxRecentTools = 6
+    private let maxRecentConversions = 10
+
+    private init() {
+        let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        baseDirectory = cachesDirectory.appendingPathComponent("com.resonans.cache", isDirectory: true)
+        exportsDirectory = baseDirectory.appendingPathComponent("exports", isDirectory: true)
+        recentToolsURL = baseDirectory.appendingPathComponent("recent-tools.json")
+        recentConversionsURL = baseDirectory.appendingPathComponent("recent-conversions.json")
+
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        createDirectoriesIfNeeded()
+    }
+
+    /// Clears any cached network responses and stored files created by the app.
     func clear() {
         URLCache.shared.removeAllCachedResponses()
+        try? fileManager.removeItem(at: baseDirectory)
+        createDirectoriesIfNeeded()
+    }
+
+    // MARK: - Recent tools
+
+    func loadRecentTools() -> [ToolItem.Identifier] {
+        guard let data = try? Data(contentsOf: recentToolsURL) else { return [] }
+        guard let rawIDs = try? decoder.decode([String].self, from: data) else {
+            try? fileManager.removeItem(at: recentToolsURL)
+            return []
+        }
+        return rawIDs.compactMap { ToolItem.Identifier(rawValue: $0) }
+    }
+
+    func saveRecentTools(_ identifiers: [ToolItem.Identifier]) {
+        let trimmed = Array(identifiers.prefix(maxRecentTools))
+        let raw = trimmed.map { $0.rawValue }
+        guard let data = try? encoder.encode(raw) else { return }
+        try? data.write(to: recentToolsURL, options: .atomic)
+    }
+
+    // MARK: - Recent conversions
+
+    func loadRecentConversions() -> [RecentItem] {
+        guard let data = try? Data(contentsOf: recentConversionsURL) else { return [] }
+        guard let decoded = try? decoder.decode([RecentItem].self, from: data) else {
+            try? fileManager.removeItem(at: recentConversionsURL)
+            return []
+        }
+
+        let existing = decoded.filter { fileManager.fileExists(atPath: $0.filePath) }
+        if existing.count != decoded.count {
+            saveRecentConversions(existing)
+        }
+        return existing
+    }
+
+    @discardableResult
+    func recordConversion(title: String, duration: String, tempURL: URL) throws -> RecentItem {
+        createDirectoriesIfNeeded()
+
+        let destination = try uniqueDestination(for: tempURL)
+
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+
+        try fileManager.moveItem(at: tempURL, to: destination)
+
+        var items = loadRecentConversions()
+        let newItem = RecentItem(title: title, duration: duration, fileURL: destination, createdAt: Date())
+
+        items.removeAll(where: { $0.id == newItem.id || $0.filePath == newItem.filePath })
+        items.insert(newItem, at: 0)
+
+        if items.count > maxRecentConversions {
+            let overflow = items.suffix(from: maxRecentConversions)
+            overflow.forEach { try? fileManager.removeItem(atPath: $0.filePath) }
+            items = Array(items.prefix(maxRecentConversions))
+        }
+
+        saveRecentConversions(items)
+
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .recentConversionsDidUpdate, object: items)
+        }
+
+        return newItem
+    }
+
+    // MARK: - Helpers
+
+    private func saveRecentConversions(_ items: [RecentItem]) {
+        guard let data = try? encoder.encode(items) else { return }
+        try? data.write(to: recentConversionsURL, options: .atomic)
+    }
+
+    private func uniqueDestination(for url: URL) throws -> URL {
+        let baseName = url.deletingPathExtension().lastPathComponent
+        let ext = url.pathExtension
+
+        var candidate = exportsDirectory.appendingPathComponent("\(baseName).\(ext)")
+        var index = 1
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = exportsDirectory.appendingPathComponent("\(baseName)-\(index).\(ext)")
+            index += 1
+        }
+        return candidate
+    }
+
+    private func createDirectoriesIfNeeded() {
+        if !fileManager.fileExists(atPath: baseDirectory.path) {
+            try? fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        }
+        if !fileManager.fileExists(atPath: exportsDirectory.path) {
+            try? fileManager.createDirectory(at: exportsDirectory, withIntermediateDirectories: true)
+        }
     }
 }
+
+extension Notification.Name {
+    static let recentConversionsDidUpdate = Notification.Name("recentConversionsDidUpdate")
+}
+

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RecentRow: View {
     let item: RecentItem
+    let onSave: (RecentItem) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     private var primary: Color { AppStyle.primary(for: colorScheme) }
@@ -33,11 +34,21 @@ struct RecentRow: View {
                     .foregroundStyle(primary.opacity(0.8))
             }
             Spacer()
+            ShareLink(item: item.fileURL) {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(primary.opacity(0.9))
+                    .padding(10)
+            }
+            .simultaneousGesture(TapGesture().onEnded {
+                HapticsManager.shared.selection()
+            })
+
             Button(action: {
                 HapticsManager.shared.pulse()
-                /* TODO: share/download */
+                onSave(item)
             }) {
-                Image(systemName: "square.and.arrow.down")
+                Image(systemName: "tray.and.arrow.down")
                     .font(.system(size: 22, weight: .bold))
                     .foregroundStyle(primary)
                     .padding(10)

--- a/Resonans/Models/RecentItem.swift
+++ b/Resonans/Models/RecentItem.swift
@@ -1,8 +1,28 @@
 import Foundation
 
-struct RecentItem: Identifiable {
-    let id = UUID()
+struct RecentItem: Identifiable, Codable, Equatable {
+    let id: UUID
     let title: String
     let duration: String
+    let filePath: String
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        duration: String,
+        fileURL: URL,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.duration = duration
+        self.filePath = fileURL.path
+        self.createdAt = createdAt
+    }
+
+    var fileURL: URL {
+        URL(fileURLWithPath: filePath)
+    }
 }
 

--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -14,7 +14,7 @@ struct ToolItem: Identifiable {
 
     static let audioExtractor = ToolItem(
         id: .audioExtractor,
-        title: "Audio Extractor",
+        title: "Extractor",
         subtitle: "Pull crisp audio tracks from your videos in seconds.",
         iconName: "waveform.circle.fill",
         gradientColors: [

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -441,7 +441,17 @@ struct ConversionSettingsView: View {
                 isProcessing = false
                 switch result {
                 case .success(let url):
-                    exportURL = url
+                    let durationLabel = formatTime(audioDuration)
+                    do {
+                        let item = try CacheManager.shared.recordConversion(
+                            title: videoURL.deletingPathExtension().lastPathComponent,
+                            duration: durationLabel,
+                            tempURL: url
+                        )
+                        exportURL = item.fileURL
+                    } catch {
+                        exportURL = url
+                    }
                     HapticsManager.shared.notify(.success)
                     showSuccessSheet = true
                 case .failure:


### PR DESCRIPTION
## Summary
- replace the extractor landing card with a streamlined header plus always-visible file and library import actions, and rename the tool to "Extractor"
- persist recently opened tools and completed conversions in the cache directory and surface them with share/save controls in the extractor view
- update the tools list so tapping a row opens the tool, refresh the tab header, and remove legacy toast messaging

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d42249d9ec83209e79e431c8e68c67