### PR TITLE
Refine audio extractor layout and navigation flow

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     }
 
     @State private var selectedTab: TabSelection = .home
+    @State private var lastPrimaryTab: TabSelection = .home
 
     @State private var homeScrollTrigger = false
     @State private var toolsScrollTrigger = false
@@ -128,6 +129,7 @@ struct ContentView: View {
             if case .tool = newValue {
                 return
             }
+            lastPrimaryTab = newValue
             if showToolCloseIcon {
                 withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
                     showToolCloseIcon = false
@@ -204,7 +206,7 @@ struct ContentView: View {
     private var headerTitle: String {
         switch selectedTab {
         case .home:
-            return "Home"
+            return "Resonans"
         case .tools:
             return "Tools"
         case .settings:
@@ -354,6 +356,12 @@ struct ContentView: View {
     }
 
     private func launchTool(_ tool: ToolItem) {
+        if case .tool = selectedTab {
+            // Preserve previously stored tab when launching from another tool
+        } else {
+            lastPrimaryTab = selectedTab
+        }
+
         selectedTool = tool.id
         updateRecents(with: tool.id)
         withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
@@ -372,7 +380,7 @@ struct ContentView: View {
         shouldSkipCloseReset = false
         if case let .tool(current) = selectedTab, current == identifier {
             withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                selectedTab = .tools
+                selectedTab = lastPrimaryTab
             }
         }
         withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {

--- a/Resonans/Views/ConversionSettingsView.swift
+++ b/Resonans/Views/ConversionSettingsView.swift
@@ -668,9 +668,15 @@ private struct VideoPreviewCard: View {
     @State private var hasLoadedMetadata = false
     @State private var showControls = true
     @State private var hideControlsWorkItem: DispatchWorkItem?
+    @State private var isLoadingPreview = true
 
     var body: some View {
-        ZStack {
+        let showLoading = isLoadingPreview && !isPlaying && thumbnail == nil
+
+        return ZStack {
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primaryColor.opacity(0.08))
+
             if let player = player, isPlaying {
                 PlayerRepresentable(player: player)
                     .scaledToFill()
@@ -679,9 +685,12 @@ private struct VideoPreviewCard: View {
                 Image(uiImage: thumbnail)
                     .resizable()
                     .scaledToFill()
-            } else {
-                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(primaryColor.opacity(0.08))
+            }
+
+            if showLoading {
+                ProgressView()
+                    .tint(primaryColor.opacity(0.6))
+                    .scaleEffect(1.1)
             }
         }
         .frame(width: size, height: size)
@@ -810,6 +819,9 @@ private struct VideoPreviewCard: View {
         hasLoadedMetadata = true
         let sourceURL = url
         Task {
+            await MainActor.run {
+                isLoadingPreview = true
+            }
             let asset = AVURLAsset(url: sourceURL)
             let durationSeconds = (try? await asset.load(.duration).seconds) ?? 0
             await MainActor.run {
@@ -826,10 +838,11 @@ private struct VideoPreviewCard: View {
                 snapshotTime = CMTime(seconds: 0, preferredTimescale: 600)
             }
             generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: snapshotTime)]) { _, cgImage, _, result, _ in
-                guard result == .succeeded, let cgImage = cgImage else { return }
-                let image = UIImage(cgImage: cgImage)
                 Task { @MainActor in
-                    thumbnail = image
+                    if result == .succeeded, let cgImage = cgImage {
+                        thumbnail = UIImage(cgImage: cgImage)
+                    }
+                    isLoadingPreview = false
                 }
             }
         }

--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -3,10 +3,14 @@ import SwiftUI
 struct AudioExtractorView: View {
     let onClose: () -> Void
 
-    @State private var videoURL: URL?
+    private struct PendingVideoSelection: Identifiable {
+        let id = UUID()
+        let url: URL
+    }
+
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
-    @State private var showConversionSheet = false
+    @State private var pendingSelection: PendingVideoSelection?
 
     @State private var recents: [RecentItem] = CacheManager.shared.loadRecentConversions()
     @State private var showAllRecents = false
@@ -25,41 +29,29 @@ struct AudioExtractorView: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: 28) {
-                Color.clear
-                    .frame(height: AppStyle.innerPadding)
-                    .padding(.bottom, -24)
-
+            VStack(spacing: 24) {
                 headerSection
 
                 sourceOptionsSection
 
                 recentSection
-
-                Spacer(minLength: 60)
             }
             .padding(.horizontal, AppStyle.horizontalPadding)
+            .padding(.vertical, AppStyle.innerPadding)
         }
-        .background(.clear)
+        .background(Color.clear)
         .sheet(isPresented: $showPhotoPicker) {
             VideoPicker { url in
-                videoURL = url
-                showConversionSheet = true
+                presentConversion(for: url)
             }
         }
         .sheet(isPresented: $showFilePicker) {
             FilePicker { url in
-                videoURL = url
-                showConversionSheet = true
+                presentConversion(for: url)
             }
         }
-        .sheet(
-            isPresented: $showConversionSheet,
-            onDismiss: { videoURL = nil }
-        ) {
-            if let url = videoURL {
-                ConversionSettingsView(videoURL: url)
-            }
+        .sheet(item: $pendingSelection) { selection in
+            ConversionSettingsView(videoURL: selection.url)
         }
         .sheet(isPresented: $showRecentExporter, onDismiss: { exportURLForRecent = nil }) {
             if let url = exportURLForRecent {
@@ -76,37 +68,58 @@ struct AudioExtractorView: View {
     }
 
     private var headerSection: some View {
-        HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Extractor")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
-                Text("Pull crisp audio from your videos")
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
+        sectionCard {
+            HStack(alignment: .top, spacing: 18) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Audio extractor")
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.65))
+
+                    Text("Pull crisp audio from your videos")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(primary)
+                        .multilineTextAlignment(.leading)
+
+                    Text("Select a source to convert footage into high quality audio in just a few taps.")
+                        .font(.system(size: 15, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .fill(accent.color.opacity(0.18))
+                    .frame(width: 54, height: 54)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                            .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                    )
+                    .overlay(
+                        Image(systemName: "waveform")
+                            .font(.system(size: 26, weight: .bold))
+                            .foregroundStyle(accent.color)
+                    )
+                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
             }
-
-            Spacer()
-
-            Image(systemName: "waveform")
-                .font(.system(size: 30, weight: .bold))
-                .foregroundStyle(accent.color)
         }
     }
 
     private var sourceOptionsSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Choose a source")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
+        sectionCard {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Choose a source")
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
 
-            HStack(spacing: 16) {
-                sourceOptionCard(icon: "doc.fill", title: "Import from Files") {
-                    showFilePicker = true
-                }
+                HStack(spacing: 16) {
+                    sourceOptionCard(icon: "doc.fill", title: "Import from Files") {
+                        showFilePicker = true
+                    }
 
-                sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Library") {
-                    showPhotoPicker = true
+                    sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Library") {
+                        showPhotoPicker = true
+                    }
                 }
             }
         }
@@ -134,54 +147,48 @@ struct AudioExtractorView: View {
     }
 
     private var recentSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Recent conversions")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.top, 16)
-                .padding(.horizontal, AppStyle.innerPadding)
+        sectionCard {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    Text("Recent conversions")
+                        .font(.system(size: 22, weight: .bold, design: .rounded))
+                        .foregroundStyle(primary)
 
-            VStack(spacing: 12) {
-                if recents.isEmpty {
-                    Text("No exports yet")
-                        .font(.system(size: 17, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.7))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 40)
-                } else {
-                    ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
-                        RecentRow(item: item, onSave: handleRecentExport)
-                            .padding(.horizontal, 12)
-                    }
+                    Spacer()
 
-                    if recents.count > 3 {
+                    if !recents.isEmpty {
                         Button {
-                            HapticsManager.shared.pulse()
+                            HapticsManager.shared.selection()
                             withAnimation(.easeInOut(duration: 0.25)) {
                                 showAllRecents.toggle()
                             }
                         } label: {
-                            Text(showAllRecents ? "Show less" : "Show more")
-                                .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.75))
+                            HStack(spacing: 6) {
+                                Text(showAllRecents ? "Show less" : "Show more")
+                                Image(systemName: showAllRecents ? "chevron.up" : "chevron.down")
+                            }
+                            .font(.system(size: 14, weight: .semibold, design: .rounded))
+                            .foregroundStyle(primary.opacity(0.7))
                         }
-                        .padding(.top, 6)
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                if recents.isEmpty {
+                    Text("No exports yet")
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 28)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
+                            RecentRow(item: item, onSave: handleRecentExport)
+                        }
                     }
                 }
             }
-            .padding(.top, 12)
-            .padding(.bottom, 18)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .appShadow(colorScheme: colorScheme, level: .medium)
     }
 
     private func reloadRecents() {
@@ -196,6 +203,20 @@ struct AudioExtractorView: View {
         }
         exportURLForRecent = url
         showRecentExporter = true
+    }
+
+    private func presentConversion(for url: URL) {
+        pendingSelection = PendingVideoSelection(url: url)
+    }
+
+    private func sectionCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            content()
+        }
+        .padding(.vertical, 24)
+        .padding(.horizontal, AppStyle.innerPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .appCardStyle(primary: primary, colorScheme: colorScheme)
     }
 }
 


### PR DESCRIPTION
## Summary
- remember the previously selected tab so closing a tool returns to where it was opened and rename the home header to "Resonans"
- rework the audio extractor layout with consistent card styling, clear backgrounds, and streamlined recent conversions
- ensure conversion always opens with the media picker selection, add loading placeholders to previews, and present a spinner while media metadata loads

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e2105c3083208665750b06e0911b