### PR TITLE
Improve navigation persistence and Audio Extractor polish

### DIFF
--- a/Resonans/Views/Tools/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/AudioExtractorView.swift
@@ -3,10 +3,9 @@ import SwiftUI
 struct AudioExtractorView: View {
     let onClose: () -> Void
 
-    @State private var videoURL: URL?
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
-    @State private var showConversionSheet = false
+    @State private var conversionSource: IdentifiedURL?
 
     @State private var recents: [RecentItem] = CacheManager.shared.loadRecentConversions()
     @State private var showAllRecents = false
@@ -25,41 +24,28 @@ struct AudioExtractorView: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: 28) {
-                Color.clear
-                    .frame(height: AppStyle.innerPadding)
-                    .padding(.bottom, -24)
-
-                headerSection
-
+            VStack(spacing: 24) {
+                heroSection
                 sourceOptionsSection
-
                 recentSection
-
-                Spacer(minLength: 60)
             }
+            .padding(.top, AppStyle.innerPadding + 12)
+            .padding(.bottom, 80)
             .padding(.horizontal, AppStyle.horizontalPadding)
         }
         .background(.clear)
         .sheet(isPresented: $showPhotoPicker) {
             VideoPicker { url in
-                videoURL = url
-                showConversionSheet = true
+                conversionSource = IdentifiedURL(url: url)
             }
         }
         .sheet(isPresented: $showFilePicker) {
             FilePicker { url in
-                videoURL = url
-                showConversionSheet = true
+                conversionSource = IdentifiedURL(url: url)
             }
         }
-        .sheet(
-            isPresented: $showConversionSheet,
-            onDismiss: { videoURL = nil }
-        ) {
-            if let url = videoURL {
-                ConversionSettingsView(videoURL: url)
-            }
+        .sheet(item: $conversionSource) { context in
+            ConversionSettingsView(videoURL: context.url)
         }
         .sheet(isPresented: $showRecentExporter, onDismiss: { exportURLForRecent = nil }) {
             if let url = exportURLForRecent {
@@ -75,39 +61,71 @@ struct AudioExtractorView: View {
         }
     }
 
-    private var headerSection: some View {
-        HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Extractor")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
-                Text("Pull crisp audio from your videos")
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
+    private var heroSection: some View {
+        sectionContainer {
+            HStack(alignment: .center, spacing: 18) {
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                accent.color.opacity(0.85),
+                                accent.color.opacity(colorScheme == .dark ? 0.55 : 0.45)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 64, height: 64)
+                    .overlay(
+                        Image(systemName: "waveform")
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundStyle(Color.white)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                            .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                    )
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Audio Extractor")
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary)
+
+                    Text("Pull crisp audio from your videos in seconds.")
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
             }
 
-            Spacer()
+            Divider()
+                .background(primary.opacity(0.08))
 
-            Image(systemName: "waveform")
-                .font(.system(size: 30, weight: .bold))
-                .foregroundStyle(accent.color)
+            VStack(alignment: .leading, spacing: 10) {
+                Label("Fast conversions with pristine quality", systemImage: "bolt.fill")
+                    .labelStyle(.titleAndIcon)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.8))
+
+                Label("Works with files and your photo library", systemImage: "folder.badge.plus")
+                    .labelStyle(.titleAndIcon)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.8))
+            }
         }
     }
 
     private var sourceOptionsSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        sectionContainer {
             Text("Choose a source")
                 .font(.system(size: 20, weight: .semibold, design: .rounded))
                 .foregroundStyle(primary)
 
-            HStack(spacing: 16) {
-                sourceOptionCard(icon: "doc.fill", title: "Import from Files") {
-                    showFilePicker = true
-                }
-
-                sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Library") {
-                    showPhotoPicker = true
-                }
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
+                sourceOptionCard(icon: "doc.fill", title: "Import from Files") { showFilePicker = true }
+                sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Library") { showPhotoPicker = true }
             }
         }
     }
@@ -134,54 +152,44 @@ struct AudioExtractorView: View {
     }
 
     private var recentSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Recent conversions")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.top, 16)
-                .padding(.horizontal, AppStyle.innerPadding)
+        sectionContainer {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Recent conversions")
+                    .font(.system(size: 22, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
 
-            VStack(spacing: 12) {
-                if recents.isEmpty {
-                    Text("No exports yet")
-                        .font(.system(size: 17, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.7))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 40)
-                } else {
-                    ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
-                        RecentRow(item: item, onSave: handleRecentExport)
-                            .padding(.horizontal, 12)
-                    }
+                Spacer()
 
-                    if recents.count > 3 {
-                        Button {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.25)) {
-                                showAllRecents.toggle()
-                            }
-                        } label: {
-                            Text(showAllRecents ? "Show less" : "Show more")
-                                .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                .foregroundStyle(primary.opacity(0.75))
+                if recents.count > 3 {
+                    Button {
+                        HapticsManager.shared.pulse()
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            showAllRecents.toggle()
                         }
-                        .padding(.top, 6)
+                    } label: {
+                        Text(showAllRecents ? "Show less" : "Show more")
+                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                            .foregroundStyle(primary.opacity(0.7))
                     }
+                    .buttonStyle(.plain)
                 }
             }
-            .padding(.top, 12)
-            .padding(.bottom, 18)
+
+            if recents.isEmpty {
+                Text("No exports yet")
+                    .font(.system(size: 17, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 36)
+            } else {
+                VStack(spacing: 12) {
+                    ForEach(recents.prefix(showAllRecents ? recents.count : 3)) { item in
+                        RecentRow(item: item, onSave: handleRecentExport)
+                    }
+                }
+                .padding(.top, 4)
+            }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .appShadow(colorScheme: colorScheme, level: .medium)
     }
 
     private func reloadRecents() {
@@ -197,8 +205,30 @@ struct AudioExtractorView: View {
         exportURLForRecent = url
         showRecentExporter = true
     }
+
+    private func sectionContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            content()
+        }
+        .padding(AppStyle.innerPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .appShadow(colorScheme: colorScheme, level: .medium)
+    }
 }
 
 #Preview {
     AudioExtractorView()
+}
+
+private struct IdentifiedURL: Identifiable {
+    let id = UUID()
+    let url: URL
 }


### PR DESCRIPTION
## Summary
- remember the last non-tool view, return to it when closing a tool, and rename the home header to "Resonans"
- refresh the Audio Extractor layout with shared section styling, updated source buttons, and a cleaner recents presentation
- ensure the conversion sheet appears immediately with a loading placeholder while video previews render

## Testing
- not run (iOS project in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e2105c3083208665750b06e0911b