### PR TITLE
Simplify navigation and unify tool styling

### DIFF
--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,11 +1,26 @@
 import SwiftUI
 
 struct ContentView: View {
-    private enum TabSelection: Hashable {
+    private enum TabSelection: CaseIterable, Hashable {
         case home
         case tools
         case settings
-        case tool(ToolItem.Identifier)
+
+        var icon: String {
+            switch self {
+            case .home: return "house.fill"
+            case .tools: return "wrench.and.screwdriver.fill"
+            case .settings: return "gearshape.fill"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .home: return "Home"
+            case .tools: return "Tools"
+            case .settings: return "Settings"
+            }
+        }
     }
 
     @State private var selectedTab: TabSelection = .home
@@ -18,9 +33,7 @@ struct ContentView: View {
     @State private var selectedTool: ToolItem.Identifier = .audioExtractor
     @State private var favoriteToolIDs: Set<ToolItem.Identifier> = [.audioExtractor]
     @State private var recentToolIDs: [ToolItem.Identifier] = CacheManager.shared.loadRecentTools()
-    @State private var activeToolID: ToolItem.Identifier?
-    @State private var showToolCloseIcon = false
-    @State private var shouldSkipCloseReset = false
+    @State private var activeTool: ToolItem?
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
@@ -33,73 +46,39 @@ struct ContentView: View {
     private var background: Color { AppStyle.background(for: colorScheme) }
     private var primary: Color { AppStyle.primary(for: colorScheme) }
 
+    private var favoriteTools: [ToolItem] {
+        tools.filter { favoriteToolIDs.contains($0.id) }
+    }
+
     private var recentTools: [ToolItem] {
         recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
     }
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            background.ignoresSafeArea()
-                .overlay(
-                    LinearGradient(
-                        colors: [accent.gradient, .clear],
-                        startPoint: .topLeading,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
-                )
+        ZStack(alignment: .bottom) {
+            LinearGradient(
+                colors: [accent.color.opacity(colorScheme == .dark ? 0.28 : 0.16), background],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
 
             VStack(spacing: 0) {
                 header
-                ZStack {
-                    TabView(selection: $selectedTab) {
-                        homeTab.tag(TabSelection.home)
-                        toolsTab.tag(TabSelection.tools)
 
-                        if let activeToolID, let tool = tools.first(where: { $0.id == activeToolID }) {
-                            toolView(for: tool)
-                                .tag(TabSelection.tool(activeToolID))
-                        }
-
-                        SettingsView(scrollToTopTrigger: $settingsScrollTrigger)
-                            .tag(TabSelection.settings)
-                    }
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                    .animation(.easeInOut(duration: 0.3), value: selectedTab)
-
-                    VStack {
-                        Spacer()
-                        ZStack {
-                            LinearGradient(
-                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                                startPoint: .bottom,
-                                endPoint: .top
-                            )
-                            .frame(height: 80)
-                            .ignoresSafeArea(edges: .bottom)
-
-                            HStack {
-                                Spacer()
-                                HStack(spacing: 32) {
-                                    bottomTabButton(systemName: "house.fill", tab: .home, trigger: $homeScrollTrigger)
-                                    bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: .tools, trigger: $toolsScrollTrigger)
-                                    if let activeToolID {
-                                        toolIconButton(for: activeToolID)
-                                            .transition(.scale.combined(with: .opacity))
-                                    }
-                                    bottomTabButton(systemName: "gearshape.fill", tab: .settings, trigger: $settingsScrollTrigger)
-                                }
-                                .padding(.horizontal, 8)
-                                .animation(.spring(response: 0.45, dampingFraction: 0.8), value: activeToolID)
-                                Spacer()
-                            }
-                            .padding(.horizontal, 40)
-                            .padding(.vertical, 12)
-                        }
-                    }
+                TabView(selection: $selectedTab) {
+                    homeTab.tag(TabSelection.home)
+                    toolsTab.tag(TabSelection.tools)
+                    SettingsView(scrollToTopTrigger: $settingsScrollTrigger)
+                        .tag(TabSelection.settings)
                 }
+                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .animation(.easeInOut(duration: 0.25), value: selectedTab)
             }
-
+        }
+        .safeAreaInset(edge: .bottom) {
+            bottomBar
         }
         .tint(accent.color)
         .animation(.easeInOut(duration: 0.4), value: colorScheme)
@@ -124,110 +103,110 @@ struct ContentView: View {
                 HapticsManager.shared.notify(.success)
             }
         }
-        .onChange(of: selectedTab) { _, newValue in
-            if case .tool = newValue {
-                return
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        }
-        .onChange(of: activeToolID) { _, newValue in
-            if newValue == nil, case .tool = selectedTab {
-                selectedTab = .tools
+        .sheet(item: $activeTool) { tool in
+            ToolSheetContainer(
+                tool: tool,
+                accent: accent.color,
+                colorScheme: colorScheme
+            ) {
+                closeActiveTool()
             }
         }
-        .simultaneousGesture(
-            TapGesture().onEnded {
-                guard showToolCloseIcon else { return }
-                if shouldSkipCloseReset {
-                    shouldSkipCloseReset = false
-                    return
-                }
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        )
     }
 
     private var header: some View {
-        HStack(alignment: .center) {
-            Text(headerTitle)
-                .font(.system(size: 46, weight: .heavy, design: .rounded))
-                .tracking(0.5)
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Resonans")
+                .font(.system(size: 34, weight: .heavy, design: .rounded))
                 .foregroundStyle(primary)
-                .appTextShadow(colorScheme: colorScheme)
-                .animation(.easeInOut(duration: 0.25), value: selectedTab)
-
-            Spacer()
-
-            headerActionButton
+            Text(headerSubtitle)
+                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.65))
+                .animation(.easeInOut(duration: 0.2), value: selectedTab)
         }
-        .padding(.horizontal, AppStyle.horizontalPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 28)
+        .padding(.top, 32)
+        .padding(.bottom, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 36, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity * 0.5))
+                .blur(radius: 30)
+                .opacity(0.6)
+                .allowsHitTesting(false)
+        )
     }
 
-    @ViewBuilder
-    private var headerActionButton: some View {
-        switch selectedTab {
-        case .tool:
-            if activeToolID != nil {
-                Button(action: {
-                    HapticsManager.shared.selection()
-                    closeActiveTool()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(primary)
-                        .appTextShadow(colorScheme: colorScheme)
+    private var bottomBar: some View {
+        HStack(spacing: 12) {
+            tabButton(for: .home, trigger: $homeScrollTrigger)
+            tabButton(for: .tools, trigger: $toolsScrollTrigger)
+            tabButton(for: .settings, trigger: $settingsScrollTrigger)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(background.opacity(colorScheme == .dark ? 0.55 : 0.88))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+                .shadow(
+                    color: AppStyle.shadowColor(for: colorScheme).opacity(colorScheme == .dark ? 0.6 : 0.18),
+                    radius: 22,
+                    x: 0,
+                    y: 18
+                )
+        )
+        .padding(.horizontal, 32)
+        .padding(.bottom, 12)
+        .animation(.easeInOut(duration: 0.3), value: selectedTab)
+    }
+
+    private func tabButton(for tab: TabSelection, trigger: Binding<Bool>) -> some View {
+        let isSelected = selectedTab == tab
+
+        return Button {
+            if isSelected {
+                trigger.wrappedValue.toggle()
+            } else {
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
+                    selectedTab = tab
                 }
-                .buttonStyle(.plain)
+                HapticsManager.shared.selection()
             }
-        case .settings:
-            Button(action: {
-                HapticsManager.shared.pulse()
-                showOnboarding = true
-            }) {
-                Image(systemName: "questionmark.circle")
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(primary)
-                    .appTextShadow(colorScheme: colorScheme)
+        } label: {
+            VStack(spacing: 8) {
+                Image(systemName: tab.icon)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(isSelected ? accent.color : primary.opacity(0.75))
+                    .frame(width: 42, height: 42)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(accent.color.opacity(isSelected ? 0.24 : 0.08))
+                    )
+                    .scaleEffect(isSelected ? 1.05 : 1.0)
+                Text(tab.title)
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundStyle(isSelected ? accent.color : primary.opacity(0.6))
             }
-            .buttonStyle(.plain)
-        default:
-            EmptyView()
+            .frame(maxWidth: .infinity)
         }
-    }
-
-    private var headerTitle: String {
-        switch selectedTab {
-        case .home:
-            return "Home"
-        case .tools:
-            return "Tools"
-        case .settings:
-            return "Settings"
-        case let .tool(identifier):
-            return tools.first(where: { $0.id == identifier })?.title ?? "Tool"
-        }
+        .buttonStyle(.plain)
     }
 
     private var homeTab: some View {
         HomeDashboardView(
-            tools: tools,
+            favoriteTools: favoriteTools,
             recentTools: recentTools,
             scrollToTopTrigger: $homeScrollTrigger,
             accent: accent,
             primary: primary,
             colorScheme: colorScheme,
-            onOpenTool: { launchTool($0) },
-            onShowTools: {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = .tools
-                }
-            }
+            onOpenTool: openTool,
+            onShowTools: { switchToTab(.tools) }
         )
     }
 
@@ -239,164 +218,84 @@ struct ContentView: View {
             accent: accent,
             primary: primary,
             colorScheme: colorScheme,
-            activeTool: activeToolID,
-            onOpen: { tool in
-                launchTool(tool)
-            },
-            onClose: { identifier in
-                if activeToolID == identifier {
-                    closeActiveTool()
-                }
-            }
+            favorites: favoriteToolIDs,
+            onOpen: openTool
         )
     }
 
-    private func symbolCompensation(for name: String) -> CGFloat {
-        switch name {
-        case "arrow.up.right.square.fill", "xmark.square.fill":
-            return 1.1
-        default:
-            return 1.0
+    private var headerSubtitle: String {
+        switch selectedTab {
+        case .home:
+            return "Your creative command centre"
+        case .tools:
+            return "Launch a workflow in a tap"
+        case .settings:
+            return "Tweak the experience to fit you"
         }
     }
 
-    private func symbolIcon(name: String, size: CGFloat, weight: Font.Weight, color: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: size, weight: weight))
-            .scaleEffect(symbolCompensation(for: name))
-            .foregroundStyle(color)
-    }
-
-    private func bottomTabButton(systemName: String, tab: TabSelection, trigger: Binding<Bool>) -> some View {
-        Button(action: {
-            HapticsManager.shared.pulse()
-            if selectedTab == tab {
-                trigger.wrappedValue.toggle()
-            } else {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = tab
-                }
-                DispatchQueue.main.async {
-                    trigger.wrappedValue.toggle()
-                }
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-            shouldSkipCloseReset = false
-        }) {
-            symbolIcon(
-                name: systemName,
-                size: 24,
-                weight: .semibold,
-                color: selectedTab == tab ? accent.color : primary.opacity(0.5)
-            )
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
+    private func switchToTab(_ tab: TabSelection) {
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
+            selectedTab = tab
         }
     }
 
-    private func toolIconButton(for identifier: ToolItem.Identifier) -> some View {
-        let isSelected: Bool
-        if case let .tool(current) = selectedTab, current == identifier {
-            isSelected = true
-        } else {
-            isSelected = false
-        }
-        return ZStack {
-            Button {
-                HapticsManager.shared.pulse()
-                if isSelected {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.7)) {
-                        showToolCloseIcon = true
-                    }
-                    shouldSkipCloseReset = true
-                } else {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                        selectedTab = .tool(identifier)
-                    }
-                    if showToolCloseIcon {
-                        showToolCloseIcon = false
-                    }
-                    shouldSkipCloseReset = false
-                }
-            } label: {
-                symbolIcon(
-                    name: "arrow.up.right.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: isSelected ? accent.color : primary.opacity(0.5)
-                )
+    private func openTool(_ tool: ToolItem) {
+        if selectedTool != tool.id {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                selectedTool = tool.id
             }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 0.01 : 1)
-            .opacity(showToolCloseIcon && isSelected ? 0 : 1)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
-
-            Button {
-                HapticsManager.shared.pulse()
-                closeActiveTool()
-            } label: {
-                symbolIcon(
-                    name: "xmark.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: accent.color
-                )
-            }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 1 : 0.01)
-            .opacity(showToolCloseIcon && isSelected ? 1 : 0)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
         }
-    }
 
-    private func launchTool(_ tool: ToolItem) {
-        selectedTool = tool.id
+        HapticsManager.shared.selection()
+        activeTool = tool
         updateRecents(with: tool.id)
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = tool.id
-            selectedTab = .tool(tool.id)
-        }
-        showToolCloseIcon = false
-        shouldSkipCloseReset = false
     }
 
     private func closeActiveTool() {
-        guard let identifier = activeToolID else { return }
-        withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-            showToolCloseIcon = false
-        }
-        shouldSkipCloseReset = false
-        if case let .tool(current) = selectedTab, current == identifier {
-            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                selectedTab = .tools
-            }
-        }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = nil
+        withAnimation(.easeInOut(duration: 0.2)) {
+            activeTool = nil
         }
     }
 
     private func updateRecents(with identifier: ToolItem.Identifier) {
-        recentToolIDs.removeAll(where: { $0 == identifier })
+        if let existingIndex = recentToolIDs.firstIndex(of: identifier) {
+            recentToolIDs.remove(at: existingIndex)
+        }
         recentToolIDs.insert(identifier, at: 0)
-        if recentToolIDs.count > 6 {
-            recentToolIDs = Array(recentToolIDs.prefix(6))
-        }
         CacheManager.shared.saveRecentTools(recentToolIDs)
-    }
-
-    @ViewBuilder
-    private func toolView(for tool: ToolItem) -> some View {
-        switch tool.id {
-        case .audioExtractor:
-            AudioExtractorView(onClose: { closeActiveTool() })
-        }
     }
 }
 
-#Preview { ContentView() }
+private struct ToolSheetContainer: View {
+    let tool: ToolItem
+    let accent: Color
+    let colorScheme: ColorScheme
+    let onClose: () -> Void
 
+    var body: some View {
+        NavigationStack {
+            tool.destination(onClose)
+                .navigationTitle(tool.title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button {
+                            HapticsManager.shared.selection()
+                            onClose()
+                        } label: {
+                            Label("Close", systemImage: "xmark")
+                                .labelStyle(.titleAndIcon)
+                        }
+                    }
+                }
+                .toolbarBackground(AppStyle.background(for: colorScheme), for: .navigationBar)
+                .toolbarBackground(.visible, for: .navigationBar)
+        }
+        .tint(accent)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -8,139 +8,119 @@ struct ToolsView: View {
     let accent: AccentColorOption
     let primary: Color
     let colorScheme: ColorScheme
-    let activeTool: ToolItem.Identifier?
+    let favorites: Set<ToolItem.Identifier>
     let onOpen: (ToolItem) -> Void
-    let onClose: (ToolItem.Identifier) -> Void
 
-    @State private var showTopBorder = false
+    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView(.vertical) {
-                VStack(spacing: 18) {
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVGrid(columns: columns, spacing: 18) {
                     Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .id("toolsTop")
+                        .frame(height: 1)
+                        .gridCellColumns(columns.count)
+                        .id("tools-top")
 
                     ForEach(tools) { tool in
-                        ToolListRow(
-                            tool: tool,
-                            primary: primary,
-                            colorScheme: colorScheme,
-                            accent: accent.color,
-                            isSelected: tool.id == selectedTool,
-                            isOpen: activeTool == tool.id,
-                            onTap: {
-                                if selectedTool != tool.id {
-                                    withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                        selectedTool = tool.id
-                                    }
-                                }
-                                onOpen(tool)
-                            },
-                            onToggleOpenState: {
-                                if activeTool == tool.id {
-                                    onClose(tool.id)
-                                } else {
-                                    if selectedTool != tool.id {
-                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                            selectedTool = tool.id
-                                        }
-                                    }
-                                    onOpen(tool)
-                                }
-                            }
-                        )
-                        .background(
-                            GeometryReader { geo -> Color in
-                                DispatchQueue.main.async {
-                                    let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
-                                    if showTopBorder != shouldShow {
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            showTopBorder = shouldShow
-                                        }
-                                    }
-                                }
-                                return Color.clear
-                            }
-                        )
+                        Button {
+                            handleSelection(for: tool)
+                        } label: {
+                            ToolTile(
+                                tool: tool,
+                                accent: accent.color,
+                                primary: primary,
+                                colorScheme: colorScheme,
+                                isHighlighted: selectedTool == tool.id,
+                                isFavorite: favorites.contains(tool.id)
+                            )
+                        }
+                        .buttonStyle(.plain)
                     }
-
-                    Spacer(minLength: 80)
                 }
                 .padding(.horizontal, AppStyle.horizontalPadding)
-            }
-            .coordinateSpace(name: "toolsScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.45))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
+                .padding(.vertical, 28)
             }
             .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    proxy.scrollTo("toolsTop", anchor: .top)
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
+                    proxy.scrollTo("tools-top", anchor: .top)
                 }
             }
         }
-        .background(
-            .clear
-        )
+        .animation(.spring(response: 0.5, dampingFraction: 0.85), value: selectedTool)
+    }
+
+    private func handleSelection(for tool: ToolItem) {
+        if selectedTool != tool.id {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                selectedTool = tool.id
+            }
+        }
+        HapticsManager.shared.selection()
+        onOpen(tool)
     }
 }
 
-private struct ToolListRow: View {
+struct ToolTile: View {
     let tool: ToolItem
+    let accent: Color
     let primary: Color
     let colorScheme: ColorScheme
-    let accent: Color
-    let isSelected: Bool
-    let isOpen: Bool
-    let onTap: () -> Void
-    let onToggleOpenState: () -> Void
+    let isHighlighted: Bool
+    let isFavorite: Bool
 
     var body: some View {
-        HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                )
-                .overlay(
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundStyle(Color.white)
-                )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 50, height: 50)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                            .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                    )
+                    .overlay(
+                        Image(systemName: tool.iconName)
+                            .font(.system(size: 22, weight: .bold))
+                            .foregroundColor(.white)
+                    )
+                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.6 : 0.15), radius: 12, x: 0, y: 8)
 
-            VStack(alignment: .leading, spacing: 6) {
+                Spacer()
+
+                if isFavorite {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(accent)
+                        .padding(6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(accent.opacity(colorScheme == .dark ? 0.25 : 0.15))
+                        )
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
                 Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
                     .foregroundStyle(primary)
-
                 Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
                     .foregroundStyle(primary.opacity(0.65))
                     .lineLimit(2)
             }
 
-            Spacer()
-
-            Button(action: {
-                HapticsManager.shared.pulse()
-                onToggleOpenState()
-            }) {
-                Image(systemName: isOpen ? "xmark" : "chevron.right")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(accent)
+            HStack(spacing: 6) {
+                Text("Open")
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 13, weight: .bold))
             }
-            .buttonStyle(.plain)
+            .foregroundStyle(accent)
         }
         .padding(.horizontal, 18)
-        .padding(.vertical, 16)
+        .padding(.vertical, 20)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                 .fill(primary.opacity(AppStyle.cardFillOpacity))
@@ -151,21 +131,16 @@ private struct ToolListRow: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(
-                    accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
-                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
-                )
+                .stroke(accent.opacity(isHighlighted ? 0.6 : 0), lineWidth: isHighlighted ? 2 : 0)
         )
-        .appShadow(
-            colorScheme: colorScheme,
-            level: .medium,
-            opacity: (isOpen || isSelected) ? 0.6 : 0.4
+        .shadow(
+            color: AppStyle.shadowColor(for: colorScheme).opacity(isHighlighted ? 0.55 : 0.35),
+            radius: isHighlighted ? 24 : 18,
+            x: 0,
+            y: isHighlighted ? 16 : 12
         )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            HapticsManager.shared.selection()
-            onTap()
-        }
+        .scaleEffect(isHighlighted ? 1.02 : 1)
+        .animation(.spring(response: 0.45, dampingFraction: 0.82), value: isHighlighted)
     }
 }
 
@@ -182,9 +157,8 @@ private struct ToolListRow: View {
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
-                activeTool: nil,
-                onOpen: { _ in },
-                onClose: { _ in }
+                favorites: Set([ToolItem.Identifier.audioExtractor]),
+                onOpen: { _ in }
             )
         }
     }


### PR DESCRIPTION
## Summary
- rebuild the main shell with a streamlined tab layout, custom bottom bar, and sheet-based tool presentation
- refresh the home dashboard to highlight favourites and recents with shared animated tool tiles
- replace the tools list with a uniform grid that reuses the new tile styling and simplifies selection handling

## Testing
- Not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e06bf24d20832092bb5f011146a972