### PR TITLE
Simplify app shell and unify design

### DIFF
--- a/Resonans/Components/ToolCard.swift
+++ b/Resonans/Components/ToolCard.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct ToolCard: View {
+    enum Layout {
+        case large
+        case compact
+    }
+
+    let tool: ToolItem
+    let layout: Layout
+    let primary: Color
+    let colorScheme: ColorScheme
+    let accent: Color
+    var isFavorite: Bool = false
+    var caption: String? = nil
+    let action: () -> Void
+
+    private var cornerRadius: CGFloat {
+        layout == .large ? AppStyle.cornerRadius : AppStyle.compactCornerRadius
+    }
+
+    private var horizontalPadding: CGFloat {
+        layout == .large ? 22 : 18
+    }
+
+    private var verticalPadding: CGFloat {
+        layout == .large ? 22 : 16
+    }
+
+    private var iconSize: CGFloat {
+        layout == .large ? 60 : 48
+    }
+
+    private var iconFontSize: CGFloat {
+        layout == .large ? 28 : 24
+    }
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            cardBody
+                .onTapGesture {
+                    HapticsManager.shared.selection()
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                        action()
+                    }
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+
+            if isFavorite {
+                favoriteBadge
+                    .padding(.trailing, 14)
+                    .padding(.top, 12)
+                    .transition(.scale.combined(with: .opacity))
+                    .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFavorite)
+            }
+        }
+    }
+
+    private var cardBody: some View {
+        VStack(alignment: .leading, spacing: layout == .large ? 18 : 14) {
+            icon
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(tool.title)
+                    .font(.system(size: layout == .large ? 22 : 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+                    .lineLimit(1)
+
+                Text(tool.subtitle)
+                    .font(.system(size: layout == .large ? 15 : 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                    .lineLimit(layout == .large ? 3 : 2)
+            }
+
+            if let caption {
+                HStack(spacing: 8) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(primary.opacity(0.45))
+                    Text(caption)
+                        .font(.system(size: 13, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.65))
+                }
+                .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .appShadow(colorScheme: colorScheme, level: layout == .large ? .large : .medium, opacity: layout == .large ? 0.55 : 0.45)
+    }
+
+    private var icon: some View {
+        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: tool.gradientColors,
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .frame(width: iconSize, height: iconSize)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(0.2), lineWidth: 1)
+            )
+            .overlay(
+                Image(systemName: tool.iconName)
+                    .font(.system(size: iconFontSize, weight: .bold))
+                    .foregroundStyle(Color.white)
+            )
+            .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
+    }
+
+    private var favoriteBadge: some View {
+        Label("Favorite", systemImage: "heart.fill")
+            .font(.system(size: 11, weight: .semibold, design: .rounded))
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(accent.opacity(colorScheme == .dark ? 0.35 : 0.25))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(accent.opacity(0.45), lineWidth: 1)
+            )
+            .foregroundStyle(accent)
+    }
+}
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var selected = false
+        var body: some View {
+            VStack(spacing: 24) {
+                ToolCard(
+                    tool: ToolItem.audioExtractor,
+                    layout: .large,
+                    primary: .black,
+                    colorScheme: .light,
+                    accent: .purple,
+                    isFavorite: true
+                ) {}
+
+                ToolCard(
+                    tool: ToolItem.audioExtractor,
+                    layout: .compact,
+                    primary: .black,
+                    colorScheme: .light,
+                    accent: .pink,
+                    caption: "Open tool"
+                ) {}
+            }
+            .padding()
+            .background(Color.white)
+        }
+    }
+    return PreviewWrapper()
+}

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,114 +1,100 @@
 import SwiftUI
 
 struct ContentView: View {
-    private enum TabSelection: Hashable {
-        case home
+    private enum Section: String, CaseIterable, Identifiable {
+        case overview
         case tools
         case settings
-        case tool(ToolItem.Identifier)
+
+        var id: Self { self }
+
+        var title: String {
+            switch self {
+            case .overview: return "Home"
+            case .tools: return "Tools"
+            case .settings: return "Settings"
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .overview: return "A calm place for every workflow"
+            case .tools: return "Pick the right helper for the job"
+            case .settings: return "Personalise Resonans to you"
+            }
+        }
     }
-
-    @State private var selectedTab: TabSelection = .home
-
-    @State private var homeScrollTrigger = false
-    @State private var toolsScrollTrigger = false
-    @State private var settingsScrollTrigger = false
-
-    private let tools = ToolItem.all
-    @State private var selectedTool: ToolItem.Identifier = .audioExtractor
-    @State private var favoriteToolIDs: Set<ToolItem.Identifier> = [.audioExtractor]
-    @State private var recentToolIDs: [ToolItem.Identifier] = CacheManager.shared.loadRecentTools()
-    @State private var activeToolID: ToolItem.Identifier?
-    @State private var showToolCloseIcon = false
-    @State private var shouldSkipCloseReset = false
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
-    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
-
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("showGuidedTips") private var showGuidedTips = true
+    @AppStorage("appearance") private var appearanceRaw = Appearance.system.rawValue
+    @AppStorage("favoriteToolsRaw") private var favoriteToolsRaw = ToolItem.Identifier.audioExtractor.rawValue
+
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+    private var appearance: Appearance { Appearance(rawValue: appearanceRaw) ?? .system }
+
+    @State private var selection: Section = .overview
+    @State private var navigationPath: [ToolItem.Identifier] = []
+    @State private var recentToolIDs: [ToolItem.Identifier] = CacheManager.shared.loadRecentTools()
+    @State private var favoriteToolIDs: Set<ToolItem.Identifier> = []
     @State private var showOnboarding = false
 
+    private let tools = ToolItem.all
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { AppStyle.background(for: colorScheme) }
+    private var backgroundColor: Color { AppStyle.background(for: colorScheme) }
     private var primary: Color { AppStyle.primary(for: colorScheme) }
 
-    private var recentTools: [ToolItem] {
-        recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
+    private var favorites: [ToolItem] {
+        let ids = favoriteToolIDs
+        return tools.filter { ids.contains($0.id) }
     }
 
+    private var recents: [ToolItem] {
+        recentToolIDs.compactMap { identifier in
+            tools.first(where: { $0.id == identifier })
+        }
+    }
+
+    @Namespace private var sectionNamespace
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            background.ignoresSafeArea()
-                .overlay(
-                    LinearGradient(
-                        colors: [accent.gradient, .clear],
-                        startPoint: .topLeading,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
-                )
+        NavigationStack(path: $navigationPath) {
+            ZStack(alignment: .top) {
+                backgroundLayer
 
-            VStack(spacing: 0) {
-                header
-                ZStack {
-                    TabView(selection: $selectedTab) {
-                        homeTab.tag(TabSelection.home)
-                        toolsTab.tag(TabSelection.tools)
+                VStack(spacing: 0) {
+                    header
+                        .padding(.horizontal, AppStyle.horizontalPadding)
+                        .padding(.top, 36)
+                        .padding(.bottom, 20)
 
-                        if let activeToolID, let tool = tools.first(where: { $0.id == activeToolID }) {
-                            toolView(for: tool)
-                                .tag(TabSelection.tool(activeToolID))
-                        }
+                    sectionPicker
+                        .padding(.horizontal, AppStyle.horizontalPadding)
 
-                        SettingsView(scrollToTopTrigger: $settingsScrollTrigger)
-                            .tag(TabSelection.settings)
-                    }
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                    .animation(.easeInOut(duration: 0.3), value: selectedTab)
-
-                    VStack {
-                        Spacer()
-                        ZStack {
-                            LinearGradient(
-                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                                startPoint: .bottom,
-                                endPoint: .top
-                            )
-                            .frame(height: 80)
-                            .ignoresSafeArea(edges: .bottom)
-
-                            HStack {
-                                Spacer()
-                                HStack(spacing: 32) {
-                                    bottomTabButton(systemName: "house.fill", tab: .home, trigger: $homeScrollTrigger)
-                                    bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: .tools, trigger: $toolsScrollTrigger)
-                                    if let activeToolID {
-                                        toolIconButton(for: activeToolID)
-                                            .transition(.scale.combined(with: .opacity))
-                                    }
-                                    bottomTabButton(systemName: "gearshape.fill", tab: .settings, trigger: $settingsScrollTrigger)
-                                }
-                                .padding(.horizontal, 8)
-                                .animation(.spring(response: 0.45, dampingFraction: 0.8), value: activeToolID)
-                                Spacer()
-                            }
-                            .padding(.horizontal, 40)
-                            .padding(.vertical, 12)
-                        }
-                    }
+                    content
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .padding(.top, 24)
                 }
             }
-
+            .navigationDestination(for: ToolItem.Identifier.self) { identifier in
+                toolDestination(for: identifier)
+            }
+            .toolbar(.hidden, for: .navigationBar)
         }
+        .preferredColorScheme(appearance.colorScheme)
         .tint(accent.color)
-        .animation(.easeInOut(duration: 0.4), value: colorScheme)
-        .animation(.easeInOut(duration: 0.4), value: accent)
-        .contentShape(Rectangle())
         .onAppear {
+            if favoriteToolIDs.isEmpty {
+                favoriteToolIDs = loadFavoriteIDs()
+            }
+            recentToolIDs = CacheManager.shared.loadRecentTools()
             if !hasCompletedOnboarding {
                 showOnboarding = true
             }
+        }
+        .onChange(of: favoriteToolIDs) { _, newValue in
+            storeFavoriteIDs(newValue)
         }
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingFlowView(
@@ -117,266 +103,172 @@ struct ContentView: View {
                 primary: primary,
                 colorScheme: colorScheme
             ) { favorites, tips in
-                favoriteToolIDs = favorites
+                let normalizedFavorites = favorites.isEmpty ? Set([ToolItem.Identifier.audioExtractor]) : favorites
+                favoriteToolIDs = normalizedFavorites
                 showGuidedTips = tips
                 hasCompletedOnboarding = true
                 showOnboarding = false
                 HapticsManager.shared.notify(.success)
             }
         }
-        .onChange(of: selectedTab) { _, newValue in
-            if case .tool = newValue {
-                return
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        }
-        .onChange(of: activeToolID) { _, newValue in
-            if newValue == nil, case .tool = selectedTab {
-                selectedTab = .tools
-            }
-        }
-        .simultaneousGesture(
-            TapGesture().onEnded {
-                guard showToolCloseIcon else { return }
-                if shouldSkipCloseReset {
-                    shouldSkipCloseReset = false
-                    return
-                }
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        )
     }
 
     private var header: some View {
-        HStack(alignment: .center) {
-            Text(headerTitle)
-                .font(.system(size: 46, weight: .heavy, design: .rounded))
-                .tracking(0.5)
-                .foregroundStyle(primary)
-                .appTextShadow(colorScheme: colorScheme)
-                .animation(.easeInOut(duration: 0.25), value: selectedTab)
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Resonans")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                    .appTextShadow(colorScheme: colorScheme)
+                Text(selection.title)
+                    .font(.system(size: 42, weight: .heavy, design: .rounded))
+                    .foregroundStyle(primary)
+                    .appTextShadow(colorScheme: colorScheme)
+                    .animation(.easeInOut(duration: 0.25), value: selection)
+                Text(selection.subtitle)
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                    .animation(.easeInOut(duration: 0.25), value: selection)
+            }
 
             Spacer()
 
-            headerActionButton
+            if selection == .settings {
+                Button {
+                    HapticsManager.shared.pulse()
+                    showOnboarding = true
+                } label: {
+                    Image(systemName: "questionmark.circle.fill")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(accent.color)
+                        .padding(12)
+                        .background(
+                            Circle()
+                                .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
+                        )
+                        .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.4)
+                }
+                .buttonStyle(.plain)
+                .transition(.scale.combined(with: .opacity))
+            }
         }
-        .padding(.horizontal, AppStyle.horizontalPadding)
     }
 
-    @ViewBuilder
-    private var headerActionButton: some View {
-        switch selectedTab {
-        case .tool:
-            if activeToolID != nil {
-                Button(action: {
+    private var sectionPicker: some View {
+        HStack(spacing: 12) {
+            ForEach(Section.allCases) { section in
+                Button {
+                    guard selection != section else { return }
                     HapticsManager.shared.selection()
-                    closeActiveTool()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(primary)
-                        .appTextShadow(colorScheme: colorScheme)
+                    withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                        selection = section
+                    }
+                } label: {
+                    Text(section.title)
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundStyle(selection == section ? primary : primary.opacity(0.6))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(
+                            ZStack {
+                                if selection == section {
+                                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                        .fill(accent.color.opacity(colorScheme == .dark ? 0.3 : 0.2))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                                .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                                        )
+                                        .matchedGeometryEffect(id: "sectionSelection", in: sectionNamespace)
+                                }
+                            }
+                        )
                 }
                 .buttonStyle(.plain)
             }
-        case .settings:
-            Button(action: {
-                HapticsManager.shared.pulse()
-                showOnboarding = true
-            }) {
-                Image(systemName: "questionmark.circle")
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(primary)
-                    .appTextShadow(colorScheme: colorScheme)
-            }
-            .buttonStyle(.plain)
-        default:
-            EmptyView()
         }
-    }
-
-    private var headerTitle: String {
-        switch selectedTab {
-        case .home:
-            return "Home"
-        case .tools:
-            return "Tools"
-        case .settings:
-            return "Settings"
-        case let .tool(identifier):
-            return tools.first(where: { $0.id == identifier })?.title ?? "Tool"
-        }
-    }
-
-    private var homeTab: some View {
-        HomeDashboardView(
-            tools: tools,
-            recentTools: recentTools,
-            scrollToTopTrigger: $homeScrollTrigger,
-            accent: accent,
-            primary: primary,
-            colorScheme: colorScheme,
-            onOpenTool: { launchTool($0) },
-            onShowTools: {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = .tools
-                }
-            }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                )
         )
+        .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
     }
 
-    private var toolsTab: some View {
-        ToolsView(
-            tools: tools,
-            selectedTool: $selectedTool,
-            scrollToTopTrigger: $toolsScrollTrigger,
-            accent: accent,
-            primary: primary,
-            colorScheme: colorScheme,
-            activeTool: activeToolID,
-            onOpen: { tool in
-                launchTool(tool)
-            },
-            onClose: { identifier in
-                if activeToolID == identifier {
-                    closeActiveTool()
-                }
+    @ViewBuilder
+    private var content: some View {
+        ZStack {
+            switch selection {
+            case .overview:
+                HomeDashboardView(
+                    favorites: favorites,
+                    recents: recents,
+                    accent: accent,
+                    primary: primary,
+                    colorScheme: colorScheme,
+                    onOpenTool: openTool,
+                    onShowTools: {
+                        withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                            selection = .tools
+                        }
+                    }
+                )
+                .transition(.opacity.combined(with: .move(edge: .leading)))
+            case .tools:
+                ToolsView(
+                    tools: tools,
+                    favorites: favoriteToolIDs,
+                    accent: accent,
+                    primary: primary,
+                    colorScheme: colorScheme,
+                    onOpen: openTool,
+                    onToggleFavorite: toggleFavorite
+                )
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+            case .settings:
+                SettingsView()
+                    .transition(.opacity)
             }
-        )
-    }
-
-    private func symbolCompensation(for name: String) -> CGFloat {
-        switch name {
-        case "arrow.up.right.square.fill", "xmark.square.fill":
-            return 1.1
-        default:
-            return 1.0
         }
+        .animation(.easeInOut(duration: 0.25), value: selection)
     }
 
-    private func symbolIcon(name: String, size: CGFloat, weight: Font.Weight, color: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: size, weight: weight))
-            .scaleEffect(symbolCompensation(for: name))
-            .foregroundStyle(color)
-    }
-
-    private func bottomTabButton(systemName: String, tab: TabSelection, trigger: Binding<Bool>) -> some View {
-        Button(action: {
-            HapticsManager.shared.pulse()
-            if selectedTab == tab {
-                trigger.wrappedValue.toggle()
-            } else {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = tab
-                }
-                DispatchQueue.main.async {
-                    trigger.wrappedValue.toggle()
-                }
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-            shouldSkipCloseReset = false
-        }) {
-            symbolIcon(
-                name: systemName,
-                size: 24,
-                weight: .semibold,
-                color: selectedTab == tab ? accent.color : primary.opacity(0.5)
+    private var backgroundLayer: some View {
+        ZStack {
+            backgroundColor
+            LinearGradient(
+                colors: [
+                    accent.color.opacity(colorScheme == .dark ? 0.34 : 0.2),
+                    accent.gradient,
+                    .clear
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
             )
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
         }
+        .ignoresSafeArea()
     }
 
-    private func toolIconButton(for identifier: ToolItem.Identifier) -> some View {
-        let isSelected: Bool
-        if case let .tool(current) = selectedTab, current == identifier {
-            isSelected = true
-        } else {
-            isSelected = false
-        }
-        return ZStack {
-            Button {
-                HapticsManager.shared.pulse()
-                if isSelected {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.7)) {
-                        showToolCloseIcon = true
-                    }
-                    shouldSkipCloseReset = true
-                } else {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                        selectedTab = .tool(identifier)
-                    }
-                    if showToolCloseIcon {
-                        showToolCloseIcon = false
-                    }
-                    shouldSkipCloseReset = false
-                }
-            } label: {
-                symbolIcon(
-                    name: "arrow.up.right.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: isSelected ? accent.color : primary.opacity(0.5)
-                )
-            }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 0.01 : 1)
-            .opacity(showToolCloseIcon && isSelected ? 0 : 1)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
-
-            Button {
-                HapticsManager.shared.pulse()
-                closeActiveTool()
-            } label: {
-                symbolIcon(
-                    name: "xmark.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: accent.color
-                )
-            }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 1 : 0.01)
-            .opacity(showToolCloseIcon && isSelected ? 1 : 0)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
-        }
-    }
-
-    private func launchTool(_ tool: ToolItem) {
-        selectedTool = tool.id
+    private func openTool(_ tool: ToolItem) {
         updateRecents(with: tool.id)
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = tool.id
-            selectedTab = .tool(tool.id)
-        }
-        showToolCloseIcon = false
-        shouldSkipCloseReset = false
-    }
-
-    private func closeActiveTool() {
-        guard let identifier = activeToolID else { return }
-        withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-            showToolCloseIcon = false
-        }
-        shouldSkipCloseReset = false
-        if case let .tool(current) = selectedTab, current == identifier {
-            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                selectedTab = .tools
+        if navigationPath.last != tool.id {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                navigationPath = [tool.id]
             }
         }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = nil
+    }
+
+    private func toggleFavorite(_ identifier: ToolItem.Identifier) {
+        if favoriteToolIDs.contains(identifier) {
+            favoriteToolIDs.remove(identifier)
+            if favoriteToolIDs.isEmpty {
+                favoriteToolIDs = [.audioExtractor]
+            }
+        } else {
+            favoriteToolIDs.insert(identifier)
         }
     }
 
@@ -390,13 +282,40 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    private func toolView(for tool: ToolItem) -> some View {
-        switch tool.id {
-        case .audioExtractor:
-            AudioExtractorView(onClose: { closeActiveTool() })
+    private func toolDestination(for identifier: ToolItem.Identifier) -> some View {
+        if let tool = tools.first(where: { $0.id == identifier }) {
+            tool.destination {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    navigationPath.removeAll(where: { $0 == identifier })
+                }
+            }
+            .navigationTitle(tool.title)
+            .navigationBarTitleDisplayMode(.inline)
+        } else {
+            EmptyView()
         }
+    }
+
+    private func loadFavoriteIDs() -> Set<ToolItem.Identifier> {
+        let components = favoriteToolsRaw.split(separator: ",").map(String.init)
+        let identifiers = components.compactMap { ToolItem.Identifier(rawValue: $0) }
+        if identifiers.isEmpty {
+            return [.audioExtractor]
+        }
+        return Set(identifiers)
+    }
+
+    private func storeFavoriteIDs(_ newValue: Set<ToolItem.Identifier>) {
+        let normalized = newValue.isEmpty ? Set([ToolItem.Identifier.audioExtractor]) : newValue
+        let raw = normalized
+            .map { $0.rawValue }
+            .sorted()
+            .joined(separator: ",")
+        favoriteToolsRaw = raw
     }
 }
 
-#Preview { ContentView() }
-
+#Preview {
+    ContentView()
+        .preferredColorScheme(.dark)
+}

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @Binding var scrollToTopTrigger: Bool
     @AppStorage("appearance") private var appearanceRaw = Appearance.system.rawValue
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
 
     @AppStorage("hapticsEnabled") private var hapticsEnabled = true
     @AppStorage("soundsEnabled") private var soundsEnabled = true
     @AppStorage("experimentalEnabled") private var experimentalEnabled = false
-    @State private var showTopBorder = false
+
+    @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
 
     private var appearance: Appearance {
         Appearance(rawValue: appearanceRaw) ?? .system
@@ -17,16 +18,14 @@ struct SettingsView: View {
     private var accent: AccentColorOption {
         AccentColorOption(rawValue: accentRaw) ?? .purple
     }
-    @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
 
     private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     private var versionDisplayString: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
-        if let version = version, !version.isEmpty {
-            if let build = build, !build.isEmpty {
+        if let version, !version.isEmpty {
+            if let build, !build.isEmpty {
                 return "\(version) (\(build))"
             }
             return version
@@ -35,109 +34,95 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 24) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .padding(.bottom, -24)
-                        .id("top")
-                    appearanceSection
-                    otherSection
-                    aboutSection
-                    Spacer(minLength: 120)
-                }
-                .padding(.bottom, AppStyle.innerPadding)
-                .background(
-                    GeometryReader { geo -> Color in
-                        DispatchQueue.main.async {
-                            let show = geo.frame(in: .named("settingsScroll")).minY < -AppStyle.innerPadding
-                            if showTopBorder != show {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    showTopBorder = show
-                                }
-                            }
-                        }
-                        return Color.clear
-                    }
-                )
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 24) {
+                sectionHeader(title: "Appearance", subtitle: "Match Resonans to your space.")
+                appearanceSection
+
+                sectionHeader(title: "Preferences", subtitle: "Tune how the app feels.")
+                otherSection
+
+                sectionHeader(title: "About", subtitle: "Details and feedback.")
+                aboutSection
             }
-            .coordinateSpace(name: "settingsScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.5))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-            }
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation {
-                    proxy.scrollTo("top", anchor: .top)
-                }
-            }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+            .padding(.vertical, 28)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .scrollIndicators(.hidden)
     }
 
-    // MARK: - Sections
+    private func sectionHeader(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(primary)
+            Text(subtitle)
+                .font(.system(size: 14, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.7))
+        }
+        .padding(.horizontal, 2)
+    }
 
     private var appearanceSection: some View {
         settingsBox {
-            Text("Appearance")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
+            Text("Theme")
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
                 .foregroundStyle(primary)
 
             HStack(spacing: 12) {
                 ForEach(Appearance.allCases) { mode in
-                    VStack(spacing: 6) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .inset(by: -4)
-                                .stroke(mode == appearance ? accent.color : .clear, lineWidth: 3)
-                                .scaleEffect(mode == appearance ? 1 : 0.9)
-                                .animation(.easeInOut(duration: 0.2), value: appearance)
-                            themePreview(for: mode)
-                                .transition(.opacity)
-                                .animation(.easeInOut(duration: 0.3), value: appearance)
-                        }
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                appearanceRaw = mode.rawValue
+                    VStack(spacing: 8) {
+                        themePreview(for: mode)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    .stroke(
+                                        accent.color.opacity(mode == appearance ? 0.8 : 0.0),
+                                        lineWidth: mode == appearance ? 3 : 0
+                                    )
+                            )
+                            .scaleEffect(mode == appearance ? 1.02 : 1.0)
+                            .animation(.easeInOut(duration: 0.2), value: appearance)
+                            .onTapGesture {
+                                HapticsManager.shared.selection()
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    appearanceRaw = mode.rawValue
+                                }
                             }
-                        }
+
                         Text(mode.label)
-                            .font(.system(size: 16, weight: .regular, design: .rounded))
+                            .font(.system(size: 15, weight: .medium, design: .rounded))
                             .foregroundStyle(primary.opacity(0.8))
                     }
                     .frame(maxWidth: .infinity)
                 }
             }
-            .padding(.top, 8)
+            .padding(.top, 6)
+
+            Divider().padding(.vertical, 8)
 
             Text("Accent color")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
                 .foregroundStyle(primary)
-                .padding(.top, 20)
 
-            HStack(spacing: 16) {
+            HStack(spacing: 14) {
                 ForEach(AccentColorOption.allCases) { option in
-                    ZStack {
-                        Circle()
-                            .stroke(primary, lineWidth: option == accent ? 3 : 0)
-                            .frame(width: 28, height: 28)
-                            .scaleEffect(option == accent ? 1.3 : 1.0)
-                            .animation(.easeInOut(duration: 0.25), value: accent)
-                        Circle()
-                            .fill(option.color)
-                            .frame(width: 28, height: 28)
-                    }
-                    .animation(.easeInOut(duration: 0.25), value: accent)
-                    .onTapGesture {
-                        HapticsManager.shared.pulse()
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            accentRaw = option.rawValue
+                    Circle()
+                        .fill(option.color)
+                        .frame(width: 28, height: 28)
+                        .overlay(
+                            Circle()
+                                .stroke(primary, lineWidth: option == accent ? 3 : 0)
+                                .scaleEffect(option == accent ? 1.2 : 1.0)
+                                .animation(.easeInOut(duration: 0.25), value: accent)
+                        )
+                        .onTapGesture {
+                            HapticsManager.shared.pulse()
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                accentRaw = option.rawValue
+                            }
                         }
-                    }
+                        .accessibilityLabel(Text(option.rawValue.capitalized))
                 }
             }
         }
@@ -145,12 +130,8 @@ struct SettingsView: View {
 
     private var otherSection: some View {
         settingsBox {
-            Text("Other")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-
             Toggle(isOn: $hapticsEnabled) {
-                Text("Vibration")
+                Text("Vibration feedback")
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: hapticsEnabled) { _, _ in
@@ -158,7 +139,7 @@ struct SettingsView: View {
             }
 
             Toggle(isOn: $soundsEnabled) {
-                Text("Sounds")
+                Text("Interface sounds")
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: soundsEnabled) { _, _ in
@@ -166,45 +147,46 @@ struct SettingsView: View {
             }
 
             Toggle(isOn: $experimentalEnabled) {
-                Text("Experimental Features")
+                Text("Experimental features")
                     .foregroundStyle(primary.opacity(0.9))
             }
             .onChange(of: experimentalEnabled) { _, _ in
                 HapticsManager.shared.selection()
             }
 
-            Divider()
-                .padding(.vertical, 4)
+            Divider().padding(.vertical, 8)
 
             Button {
                 CacheManager.shared.clear()
                 HapticsManager.shared.notify(.success)
             } label: {
-                Text("Clear Cache")
+                Label("Clear cache", systemImage: "arrow.uturn.backward")
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
                     .foregroundStyle(primary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(accent.color.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+                    .background(accent.color.opacity(colorScheme == .dark ? 0.25 : 0.18))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                    )
             }
-            .padding(.top, 4)
+            .buttonStyle(.plain)
         }
     }
 
     private var aboutSection: some View {
         settingsBox {
-            Text("About")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-
             HStack {
                 Text("Version")
+                    .foregroundStyle(primary.opacity(0.8))
                 Spacer()
                 Text(versionDisplayString)
+                    .foregroundStyle(primary)
             }
-            .foregroundStyle(primary.opacity(0.8))
+
+            Divider().padding(.vertical, 8)
 
             Button {
                 HapticsManager.shared.pulse()
@@ -212,20 +194,21 @@ struct SettingsView: View {
                     openURL(url)
                 }
             } label: {
-                Text("Send Feedback")
+                Label("Send feedback", systemImage: "paperplane.fill")
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
                     .foregroundStyle(primary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(accent.color.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity)
+                    .background(accent.color.opacity(colorScheme == .dark ? 0.25 : 0.18))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                    )
             }
-            .padding(.top, 12)
+            .buttonStyle(.plain)
         }
     }
-
-    // MARK: - Helpers
 
     @ViewBuilder
     private func themePreview(for mode: Appearance) -> some View {
@@ -234,25 +217,22 @@ struct SettingsView: View {
             Image("white")
                 .resizable()
                 .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
+                .cornerRadius(16)
         case .dark:
             Image("dark")
                 .resizable()
                 .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
+                .cornerRadius(16)
         case .system:
             Image("darkandwhite")
                 .resizable()
                 .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
+                .cornerRadius(16)
         }
     }
 
     private func settingsBox<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 18) {
             content()
         }
         .padding(AppStyle.innerPadding)
@@ -263,12 +243,11 @@ struct SettingsView: View {
             fillOpacity: AppStyle.subtleCardFillOpacity,
             shadowLevel: .medium
         )
-        .padding(.horizontal, AppStyle.horizontalPadding)
     }
 }
 
 #Preview {
-    SettingsView(scrollToTopTrigger: .constant(false))
+    SettingsView()
         .background(Color.black)
         .preferredColorScheme(.dark)
 }

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -2,189 +2,71 @@ import SwiftUI
 
 struct ToolsView: View {
     let tools: [ToolItem]
-    @Binding var selectedTool: ToolItem.Identifier
-    @Binding var scrollToTopTrigger: Bool
-
+    let favorites: Set<ToolItem.Identifier>
     let accent: AccentColorOption
     let primary: Color
     let colorScheme: ColorScheme
-    let activeTool: ToolItem.Identifier?
     let onOpen: (ToolItem) -> Void
-    let onClose: (ToolItem.Identifier) -> Void
-
-    @State private var showTopBorder = false
+    let onToggleFavorite: (ToolItem.Identifier) -> Void
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical) {
-                VStack(spacing: 18) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .id("toolsTop")
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Creative toolkit")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .foregroundStyle(primary)
 
+                Text("Choose a tool to get started. Long-press a card to pin or unpin it from your favourites.")
+                    .font(.system(size: 15, weight: .medium, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+
+                LazyVStack(spacing: 18) {
                     ForEach(tools) { tool in
-                        ToolListRow(
+                        ToolCard(
                             tool: tool,
+                            layout: .large,
                             primary: primary,
                             colorScheme: colorScheme,
                             accent: accent.color,
-                            isSelected: tool.id == selectedTool,
-                            isOpen: activeTool == tool.id,
-                            onTap: {
-                                if selectedTool != tool.id {
-                                    withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                        selectedTool = tool.id
-                                    }
+                            isFavorite: favorites.contains(tool.id),
+                            caption: "Open tool"
+                        ) {
+                            onOpen(tool)
+                        }
+                        .contextMenu {
+                            Button {
+                                HapticsManager.shared.selection()
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    onToggleFavorite(tool.id)
                                 }
-                                onOpen(tool)
-                            },
-                            onToggleOpenState: {
-                                if activeTool == tool.id {
-                                    onClose(tool.id)
-                                } else {
-                                    if selectedTool != tool.id {
-                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                            selectedTool = tool.id
-                                        }
-                                    }
-                                    onOpen(tool)
-                                }
+                            } label: {
+                                Label(
+                                    favorites.contains(tool.id) ? "Remove from favourites" : "Add to favourites",
+                                    systemImage: favorites.contains(tool.id) ? "heart.slash" : "heart"
+                                )
                             }
-                        )
-                        .background(
-                            GeometryReader { geo -> Color in
-                                DispatchQueue.main.async {
-                                    let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
-                                    if showTopBorder != shouldShow {
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            showTopBorder = shouldShow
-                                        }
-                                    }
-                                }
-                                return Color.clear
-                            }
-                        )
+                        }
                     }
-
-                    Spacer(minLength: 80)
-                }
-                .padding(.horizontal, AppStyle.horizontalPadding)
-            }
-            .coordinateSpace(name: "toolsScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.45))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-            }
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    proxy.scrollTo("toolsTop", anchor: .top)
                 }
             }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+            .padding(.vertical, 24)
         }
-        .background(
-            .clear
-        )
-    }
-}
-
-private struct ToolListRow: View {
-    let tool: ToolItem
-    let primary: Color
-    let colorScheme: ColorScheme
-    let accent: Color
-    let isSelected: Bool
-    let isOpen: Bool
-    let onTap: () -> Void
-    let onToggleOpenState: () -> Void
-
-    var body: some View {
-        HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                )
-                .overlay(
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundStyle(Color.white)
-                )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-
-                Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
-                    .lineLimit(2)
-            }
-
-            Spacer()
-
-            Button(action: {
-                HapticsManager.shared.pulse()
-                onToggleOpenState()
-            }) {
-                Image(systemName: isOpen ? "xmark" : "chevron.right")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(accent)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(
-                    accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
-                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
-                )
-        )
-        .appShadow(
-            colorScheme: colorScheme,
-            level: .medium,
-            opacity: (isOpen || isSelected) ? 0.6 : 0.4
-        )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            HapticsManager.shared.selection()
-            onTap()
-        }
+        .scrollIndicators(.hidden)
     }
 }
 
 #Preview {
     struct PreviewWrapper: View {
-        @State private var selected = ToolItem.Identifier.audioExtractor
-        @State private var trigger = false
-
         var body: some View {
             ToolsView(
                 tools: ToolItem.all,
-                selectedTool: $selected,
-                scrollToTopTrigger: $trigger,
+                favorites: [.audioExtractor],
                 accent: .purple,
                 primary: .black,
                 colorScheme: .light,
-                activeTool: nil,
                 onOpen: { _ in },
-                onClose: { _ in }
+                onToggleFavorite: { _ in }
             )
         }
     }


### PR DESCRIPTION
## Summary
- replace the previous multi-tab shell with a streamlined navigation stack, animated section picker, and onboarding persistence
- introduce a reusable ToolCard component and refresh the home and tools sections to present tools with consistent cards and subtle motion
- simplify the settings layout with card-based sections and clearer controls while keeping existing functionality intact

## Testing
- Not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e06bf24d20832092bb5f011146a972