### PR TITLE
Refine tool row styling and reuse card component

### DIFF
--- a/Resonans/Components/ToolRowCard.swift
+++ b/Resonans/Components/ToolRowCard.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct ToolRowCard<Accessory: View>: View {
+    let tool: ToolItem
+    let primary: Color
+    let colorScheme: ColorScheme
+    let subtitleSpacing: CGFloat
+    let subtitleColor: Color
+    let shadowLevel: AppStyle.ShadowLevel
+    let shadowOpacity: Double?
+    private let accessory: Accessory
+
+    init(
+        tool: ToolItem,
+        primary: Color,
+        colorScheme: ColorScheme,
+        subtitleSpacing: CGFloat = 4,
+        subtitleColor: Color? = nil,
+        shadowLevel: AppStyle.ShadowLevel = .medium,
+        shadowOpacity: Double? = nil,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        self.tool = tool
+        self.primary = primary
+        self.colorScheme = colorScheme
+        self.subtitleSpacing = subtitleSpacing
+        self.subtitleColor = subtitleColor ?? primary.opacity(0.65)
+        self.shadowLevel = shadowLevel
+        self.shadowOpacity = shadowOpacity
+        self.accessory = accessory()
+    }
+
+    init(
+        tool: ToolItem,
+        primary: Color,
+        colorScheme: ColorScheme,
+        subtitleSpacing: CGFloat = 4,
+        subtitleColor: Color? = nil,
+        shadowLevel: AppStyle.ShadowLevel = .medium,
+        shadowOpacity: Double? = nil
+    ) where Accessory == EmptyView {
+        self.init(
+            tool: tool,
+            primary: primary,
+            colorScheme: colorScheme,
+            subtitleSpacing: subtitleSpacing,
+            subtitleColor: subtitleColor,
+            shadowLevel: shadowLevel,
+            shadowOpacity: shadowOpacity
+        ) {
+            EmptyView()
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ToolIconView(tool: tool, colorScheme: colorScheme)
+
+            VStack(alignment: .leading, spacing: subtitleSpacing) {
+                Text(tool.title)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary)
+
+                Text(tool.subtitle)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundStyle(subtitleColor)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            accessory
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .appCardStyle(
+            primary: primary,
+            colorScheme: colorScheme,
+            shadowLevel: shadowLevel,
+            shadowOpacity: shadowOpacity
+        )
+    }
+}
+
+struct ToolIconView: View {
+    let tool: ToolItem
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: tool.gradientColors,
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .frame(width: 52, height: 52)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            )
+            .overlay(
+                Image(systemName: tool.iconName)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(Color.white)
+            )
+            .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
+    }
+}

--- a/Resonans/StyleConstants.swift
+++ b/Resonans/StyleConstants.swift
@@ -117,6 +117,7 @@ private struct AppCardStyleModifier: ViewModifier {
     let fillOpacity: Double
     let strokeOpacity: Double
     let shadowLevel: AppStyle.ShadowLevel
+    let shadowOpacity: Double?
 
     func body(content: Content) -> some View {
         content
@@ -129,7 +130,13 @@ private struct AppCardStyleModifier: ViewModifier {
                     )
             )
             .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .modifier(AppShadowModifier(colorScheme: colorScheme, level: shadowLevel, overrideOpacity: nil))
+            .modifier(
+                AppShadowModifier(
+                    colorScheme: colorScheme,
+                    level: shadowLevel,
+                    overrideOpacity: shadowOpacity
+                )
+            )
     }
 }
 
@@ -148,7 +155,8 @@ extension View {
         cornerRadius: CGFloat = AppStyle.cornerRadius,
         fillOpacity: Double = AppStyle.cardFillOpacity,
         strokeOpacity: Double = AppStyle.strokeOpacity,
-        shadowLevel: AppStyle.ShadowLevel = .medium
+        shadowLevel: AppStyle.ShadowLevel = .medium,
+        shadowOpacity: Double? = nil
     ) -> some View {
         modifier(
             AppCardStyleModifier(
@@ -157,7 +165,8 @@ extension View {
                 cornerRadius: cornerRadius,
                 fillOpacity: fillOpacity,
                 strokeOpacity: strokeOpacity,
-                shadowLevel: shadowLevel
+                shadowLevel: shadowLevel,
+                shadowOpacity: shadowOpacity
             )
         )
     }

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -161,48 +161,17 @@ private struct ToolHistoryRow: View {
     let colorScheme: ColorScheme
 
     var body: some View {
-        HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                )
-                .overlay(
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(.white)
-                )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-                Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
-                    .lineLimit(2)
-            }
-
-            Spacer()
-
+        ToolRowCard(
+            tool: tool,
+            primary: primary,
+            colorScheme: colorScheme,
+            subtitleSpacing: 4,
+            shadowLevel: .small
+        ) {
             Image(systemName: "chevron.right")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(primary.opacity(0.4))
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .appShadow(colorScheme: colorScheme, level: .small)
     }
 }
 

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -101,34 +101,13 @@ private struct ToolListRow: View {
     let onToggleOpenState: () -> Void
 
     var body: some View {
-        HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
-                )
-                .overlay(
-                    Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundStyle(Color.white)
-                )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-
-                Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
-                    .lineLimit(2)
-            }
-
-            Spacer()
-
+        ToolRowCard(
+            tool: tool,
+            primary: primary,
+            colorScheme: colorScheme,
+            subtitleSpacing: 6,
+            shadowOpacity: (isOpen || isSelected) ? 0.6 : 0.4
+        ) {
             Button(action: {
                 HapticsManager.shared.pulse()
                 onToggleOpenState()
@@ -139,27 +118,12 @@ private struct ToolListRow: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                 .stroke(
                     accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
                     lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
                 )
-        )
-        .appShadow(
-            colorScheme: colorScheme,
-            level: .medium,
-            opacity: (isOpen || isSelected) ? 0.6 : 0.4
         )
         .contentShape(Rectangle())
         .onTapGesture {


### PR DESCRIPTION
## Summary
- create a reusable `ToolRowCard` component to standardize tool row layout and gradients
- update the tools list and recent history rows to adopt the shared card, reducing duplicated styling logic
- let `appCardStyle` accept an optional shadow opacity override so the shared card can adjust emphasis

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e06f2570b48320a55da4af4dab4304