### PR TITLE
Refresh navigation and styling

### DIFF
--- a/Resonans/AppTheme.swift
+++ b/Resonans/AppTheme.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct AppTheme {
+    let accent: AccentColorOption
+    let colorScheme: ColorScheme
+
+    var accentColor: Color { accent.color }
+
+    var background: Color {
+        if colorScheme == .dark {
+            return Color(.systemBackground)
+        } else {
+            return Color(.systemGroupedBackground)
+        }
+    }
+
+    var foreground: Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    var secondary: Color {
+        foreground.opacity(0.7)
+    }
+
+    var tertiary: Color {
+        foreground.opacity(0.5)
+    }
+
+    var surface: Color {
+        if colorScheme == .dark {
+            return Color.white.opacity(0.08)
+        } else {
+            return Color.white
+        }
+    }
+
+    var subtleSurface: Color {
+        if colorScheme == .dark {
+            return Color.white.opacity(0.05)
+        } else {
+            return Color.black.opacity(0.03)
+        }
+    }
+
+    var border: Color {
+        if colorScheme == .dark {
+            return Color.white.opacity(0.15)
+        } else {
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    var separator: Color {
+        if colorScheme == .dark {
+            return Color.white.opacity(0.12)
+        } else {
+            return Color.black.opacity(0.12)
+        }
+    }
+
+    var shadow: Color {
+        if colorScheme == .dark {
+            return Color.black.opacity(0.45)
+        } else {
+            return Color.black.opacity(0.08)
+        }
+    }
+
+    var buttonBackground: Color {
+        accentColor.opacity(colorScheme == .dark ? 0.3 : 0.15)
+    }
+}
+
+struct SurfaceCard<Content: View>: View {
+    let theme: AppTheme
+    let padding: CGFloat
+    let content: Content
+
+    init(theme: AppTheme, padding: CGFloat = 20, @ViewBuilder content: () -> Content) {
+        self.theme = theme
+        self.padding = padding
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(padding)
+            .background(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(theme.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 22, style: .continuous)
+                            .stroke(theme.border, lineWidth: 1)
+                    )
+            )
+            .shadow(color: theme.shadow, radius: 12, x: 0, y: 6)
+    }
+}
+
+extension View {
+    func themedBackground(_ theme: AppTheme) -> some View {
+        background(theme.background.ignoresSafeArea())
+    }
+}

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -2,69 +2,75 @@ import SwiftUI
 
 struct RecentRow: View {
     let item: RecentItem
+    let theme: AppTheme
     let onSave: (RecentItem) -> Void
-
-    @Environment(\.colorScheme) private var colorScheme
-    private var primary: Color { AppStyle.primary(for: colorScheme) }
 
     var body: some View {
         HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.iconFillOpacity))
-                .frame(width: 56, height: 56)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(theme.subtleSurface)
+                .frame(width: 52, height: 52)
                 .overlay(
                     Image(systemName: "waveform")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(primary.opacity(0.9))
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(theme.foreground)
                 )
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.iconStrokeOpacity), lineWidth: 1)
-                )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(item.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(theme.foreground)
                     .lineLimit(1)
-                    .truncationMode(.tail)
                 Text(item.duration)
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundStyle(primary.opacity(0.8))
+                    .font(.footnote)
+                    .foregroundStyle(theme.secondary)
             }
+
             Spacer()
+
             ShareLink(item: item.fileURL) {
                 Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(primary.opacity(0.9))
+                    .foregroundStyle(theme.accentColor)
                     .padding(10)
+                    .background(theme.buttonBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
+            .buttonStyle(.plain)
             .simultaneousGesture(TapGesture().onEnded {
                 HapticsManager.shared.selection()
             })
 
-            Button(action: {
-                HapticsManager.shared.pulse()
+            Button {
+                HapticsManager.shared.selection()
                 onSave(item)
-            }) {
+            } label: {
                 Image(systemName: "tray.and.arrow.down")
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(primary)
+                    .foregroundStyle(theme.accentColor)
                     .padding(10)
+                    .background(theme.buttonBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
             .buttonStyle(.plain)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .appCardStyle(
-            primary: primary,
-            colorScheme: colorScheme,
-            cornerRadius: AppStyle.compactCornerRadius,
-            fillOpacity: AppStyle.compactCardFillOpacity,
-            shadowLevel: .small
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(theme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(theme.border, lineWidth: 1)
+                )
         )
     }
 }
 
+#Preview {
+    RecentRow(
+        item: RecentItem(title: "Sample clip", duration: "1:20", fileURL: URL(filePath: "/tmp/sample.mp3"), createdAt: Date()),
+        theme: AppTheme(accent: .purple, colorScheme: .light),
+        onSave: { _ in }
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -1,110 +1,98 @@
 import SwiftUI
 
 struct ContentView: View {
-    private enum TabSelection: Hashable {
+    private enum Tab: Hashable {
         case home
         case tools
         case settings
-        case tool(ToolItem.Identifier)
     }
 
-    @State private var selectedTab: TabSelection = .home
-
-    @State private var homeScrollTrigger = false
-    @State private var toolsScrollTrigger = false
-    @State private var settingsScrollTrigger = false
+    @State private var selectedTab: Tab = .home
+    @State private var presentedTool: ToolItem?
 
     private let tools = ToolItem.all
-    @State private var selectedTool: ToolItem.Identifier = .audioExtractor
     @State private var favoriteToolIDs: Set<ToolItem.Identifier> = [.audioExtractor]
     @State private var recentToolIDs: [ToolItem.Identifier] = CacheManager.shared.loadRecentTools()
-    @State private var activeToolID: ToolItem.Identifier?
-    @State private var showToolCloseIcon = false
-    @State private var shouldSkipCloseReset = false
 
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
-    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
-
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("showGuidedTips") private var showGuidedTips = true
     @State private var showOnboarding = false
 
     @Environment(\.colorScheme) private var colorScheme
-    private var background: Color { AppStyle.background(for: colorScheme) }
-    private var primary: Color { AppStyle.primary(for: colorScheme) }
+
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+    private var theme: AppTheme { AppTheme(accent: accent, colorScheme: colorScheme) }
 
     private var recentTools: [ToolItem] {
         recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
     }
 
+    private var favoriteTools: [ToolItem] {
+        tools.filter { favoriteToolIDs.contains($0.id) }
+    }
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            background.ignoresSafeArea()
-                .overlay(
-                    LinearGradient(
-                        colors: [accent.gradient, .clear],
-                        startPoint: .topLeading,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                HomeDashboardView(
+                    theme: theme,
+                    favoriteTools: favoriteTools,
+                    recentTools: recentTools,
+                    allTools: tools,
+                    onSelectTool: open,
+                    onShowAllTools: {
+                        HapticsManager.shared.selection()
+                        selectedTab = .tools
+                    }
                 )
-
-            VStack(spacing: 0) {
-                header
-                ZStack {
-                    TabView(selection: $selectedTab) {
-                        homeTab.tag(TabSelection.home)
-                        toolsTab.tag(TabSelection.tools)
-
-                        if let activeToolID, let tool = tools.first(where: { $0.id == activeToolID }) {
-                            toolView(for: tool)
-                                .tag(TabSelection.tool(activeToolID))
-                        }
-
-                        SettingsView(scrollToTopTrigger: $settingsScrollTrigger)
-                            .tag(TabSelection.settings)
-                    }
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                    .animation(.easeInOut(duration: 0.3), value: selectedTab)
-
-                    VStack {
-                        Spacer()
-                        ZStack {
-                            LinearGradient(
-                                gradient: Gradient(colors: [background, background.opacity(0.0)]),
-                                startPoint: .bottom,
-                                endPoint: .top
-                            )
-                            .frame(height: 80)
-                            .ignoresSafeArea(edges: .bottom)
-
-                            HStack {
-                                Spacer()
-                                HStack(spacing: 32) {
-                                    bottomTabButton(systemName: "house.fill", tab: .home, trigger: $homeScrollTrigger)
-                                    bottomTabButton(systemName: "wrench.and.screwdriver.fill", tab: .tools, trigger: $toolsScrollTrigger)
-                                    if let activeToolID {
-                                        toolIconButton(for: activeToolID)
-                                            .transition(.scale.combined(with: .opacity))
-                                    }
-                                    bottomTabButton(systemName: "gearshape.fill", tab: .settings, trigger: $settingsScrollTrigger)
-                                }
-                                .padding(.horizontal, 8)
-                                .animation(.spring(response: 0.45, dampingFraction: 0.8), value: activeToolID)
-                                Spacer()
-                            }
-                            .padding(.horizontal, 40)
-                            .padding(.vertical, 12)
-                        }
-                    }
-                }
+                .navigationTitle("Home")
+                .navigationBarTitleDisplayMode(.large)
+                .background(theme.background)
             }
+            .tabItem { Label("Home", systemImage: "house.fill") }
+            .tag(Tab.home)
 
+            NavigationStack {
+                ToolsView(
+                    theme: theme,
+                    tools: tools,
+                    favorites: $favoriteToolIDs,
+                    onSelectTool: open
+                )
+                .navigationTitle("Tools")
+                .navigationBarTitleDisplayMode(.large)
+                .background(theme.background)
+            }
+            .tabItem { Label("Tools", systemImage: "wrench.and.screwdriver.fill") }
+            .tag(Tab.tools)
+
+            NavigationStack {
+                SettingsView(theme: theme) {
+                    showOnboarding = true
+                }
+                .navigationTitle("Settings")
+                .navigationBarTitleDisplayMode(.large)
+                .background(theme.background)
+            }
+            .tabItem { Label("Settings", systemImage: "gearshape.fill") }
+            .tag(Tab.settings)
         }
-        .tint(accent.color)
-        .animation(.easeInOut(duration: 0.4), value: colorScheme)
-        .animation(.easeInOut(duration: 0.4), value: accent)
-        .contentShape(Rectangle())
+        .tint(theme.accentColor)
+        .background(theme.background.ignoresSafeArea())
+        .sheet(item: $presentedTool) { tool in
+            NavigationStack {
+                tool.destination { presentedTool = nil }
+                    .navigationTitle(tool.title)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { presentedTool = nil }
+                        }
+                    }
+            }
+            .tint(theme.accentColor)
+        }
         .onAppear {
             if !hasCompletedOnboarding {
                 showOnboarding = true
@@ -113,8 +101,8 @@ struct ContentView: View {
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingFlowView(
                 tools: tools,
-                accent: accent.color,
-                primary: primary,
+                accent: theme.accentColor,
+                primary: theme.foreground,
                 colorScheme: colorScheme
             ) { favorites, tips in
                 favoriteToolIDs = favorites
@@ -124,260 +112,12 @@ struct ContentView: View {
                 HapticsManager.shared.notify(.success)
             }
         }
-        .onChange(of: selectedTab) { _, newValue in
-            if case .tool = newValue {
-                return
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        }
-        .onChange(of: activeToolID) { _, newValue in
-            if newValue == nil, case .tool = selectedTab {
-                selectedTab = .tools
-            }
-        }
-        .simultaneousGesture(
-            TapGesture().onEnded {
-                guard showToolCloseIcon else { return }
-                if shouldSkipCloseReset {
-                    shouldSkipCloseReset = false
-                    return
-                }
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-        )
     }
 
-    private var header: some View {
-        HStack(alignment: .center) {
-            Text(headerTitle)
-                .font(.system(size: 46, weight: .heavy, design: .rounded))
-                .tracking(0.5)
-                .foregroundStyle(primary)
-                .appTextShadow(colorScheme: colorScheme)
-                .animation(.easeInOut(duration: 0.25), value: selectedTab)
-
-            Spacer()
-
-            headerActionButton
-        }
-        .padding(.horizontal, AppStyle.horizontalPadding)
-    }
-
-    @ViewBuilder
-    private var headerActionButton: some View {
-        switch selectedTab {
-        case .tool:
-            if activeToolID != nil {
-                Button(action: {
-                    HapticsManager.shared.selection()
-                    closeActiveTool()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(primary)
-                        .appTextShadow(colorScheme: colorScheme)
-                }
-                .buttonStyle(.plain)
-            }
-        case .settings:
-            Button(action: {
-                HapticsManager.shared.pulse()
-                showOnboarding = true
-            }) {
-                Image(systemName: "questionmark.circle")
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(primary)
-                    .appTextShadow(colorScheme: colorScheme)
-            }
-            .buttonStyle(.plain)
-        default:
-            EmptyView()
-        }
-    }
-
-    private var headerTitle: String {
-        switch selectedTab {
-        case .home:
-            return "Home"
-        case .tools:
-            return "Tools"
-        case .settings:
-            return "Settings"
-        case let .tool(identifier):
-            return tools.first(where: { $0.id == identifier })?.title ?? "Tool"
-        }
-    }
-
-    private var homeTab: some View {
-        HomeDashboardView(
-            tools: tools,
-            recentTools: recentTools,
-            scrollToTopTrigger: $homeScrollTrigger,
-            accent: accent,
-            primary: primary,
-            colorScheme: colorScheme,
-            onOpenTool: { launchTool($0) },
-            onShowTools: {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = .tools
-                }
-            }
-        )
-    }
-
-    private var toolsTab: some View {
-        ToolsView(
-            tools: tools,
-            selectedTool: $selectedTool,
-            scrollToTopTrigger: $toolsScrollTrigger,
-            accent: accent,
-            primary: primary,
-            colorScheme: colorScheme,
-            activeTool: activeToolID,
-            onOpen: { tool in
-                launchTool(tool)
-            },
-            onClose: { identifier in
-                if activeToolID == identifier {
-                    closeActiveTool()
-                }
-            }
-        )
-    }
-
-    private func symbolCompensation(for name: String) -> CGFloat {
-        switch name {
-        case "arrow.up.right.square.fill", "xmark.square.fill":
-            return 1.1
-        default:
-            return 1.0
-        }
-    }
-
-    private func symbolIcon(name: String, size: CGFloat, weight: Font.Weight, color: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: size, weight: weight))
-            .scaleEffect(symbolCompensation(for: name))
-            .foregroundStyle(color)
-    }
-
-    private func bottomTabButton(systemName: String, tab: TabSelection, trigger: Binding<Bool>) -> some View {
-        Button(action: {
-            HapticsManager.shared.pulse()
-            if selectedTab == tab {
-                trigger.wrappedValue.toggle()
-            } else {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    selectedTab = tab
-                }
-                DispatchQueue.main.async {
-                    trigger.wrappedValue.toggle()
-                }
-            }
-            if showToolCloseIcon {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                    showToolCloseIcon = false
-                }
-            }
-            shouldSkipCloseReset = false
-        }) {
-            symbolIcon(
-                name: systemName,
-                size: 24,
-                weight: .semibold,
-                color: selectedTab == tab ? accent.color : primary.opacity(0.5)
-            )
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
-        }
-    }
-
-    private func toolIconButton(for identifier: ToolItem.Identifier) -> some View {
-        let isSelected: Bool
-        if case let .tool(current) = selectedTab, current == identifier {
-            isSelected = true
-        } else {
-            isSelected = false
-        }
-        return ZStack {
-            Button {
-                HapticsManager.shared.pulse()
-                if isSelected {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.7)) {
-                        showToolCloseIcon = true
-                    }
-                    shouldSkipCloseReset = true
-                } else {
-                    withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                        selectedTab = .tool(identifier)
-                    }
-                    if showToolCloseIcon {
-                        showToolCloseIcon = false
-                    }
-                    shouldSkipCloseReset = false
-                }
-            } label: {
-                symbolIcon(
-                    name: "arrow.up.right.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: isSelected ? accent.color : primary.opacity(0.5)
-                )
-            }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 0.01 : 1)
-            .opacity(showToolCloseIcon && isSelected ? 0 : 1)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
-            .animation(.easeInOut(duration: 0.25), value: selectedTab)
-
-            Button {
-                HapticsManager.shared.pulse()
-                closeActiveTool()
-            } label: {
-                symbolIcon(
-                    name: "xmark.square.fill",
-                    size: 24,
-                    weight: .semibold,
-                    color: accent.color
-                )
-            }
-            .buttonStyle(.plain)
-            .scaleEffect(showToolCloseIcon && isSelected ? 1 : 0.01)
-            .opacity(showToolCloseIcon && isSelected ? 1 : 0)
-            .animation(.spring(response: 0.45, dampingFraction: 0.75), value: showToolCloseIcon)
-        }
-    }
-
-    private func launchTool(_ tool: ToolItem) {
-        selectedTool = tool.id
+    private func open(_ tool: ToolItem) {
         updateRecents(with: tool.id)
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = tool.id
-            selectedTab = .tool(tool.id)
-        }
-        showToolCloseIcon = false
-        shouldSkipCloseReset = false
-    }
-
-    private func closeActiveTool() {
-        guard let identifier = activeToolID else { return }
-        withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-            showToolCloseIcon = false
-        }
-        shouldSkipCloseReset = false
-        if case let .tool(current) = selectedTab, current == identifier {
-            withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                selectedTab = .tools
-            }
-        }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-            activeToolID = nil
-        }
+        HapticsManager.shared.selection()
+        presentedTool = tool
     }
 
     private func updateRecents(with identifier: ToolItem.Identifier) {
@@ -388,15 +128,9 @@ struct ContentView: View {
         }
         CacheManager.shared.saveRecentTools(recentToolIDs)
     }
-
-    @ViewBuilder
-    private func toolView(for tool: ToolItem) -> some View {
-        switch tool.id {
-        case .audioExtractor:
-            AudioExtractorView(onClose: { closeActiveTool() })
-        }
-    }
 }
 
-#Preview { ContentView() }
-
+#Preview {
+    ContentView()
+        .preferredColorScheme(.light)
+}

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -1,227 +1,213 @@
 import SwiftUI
 
 struct HomeDashboardView: View {
-    let tools: [ToolItem]
+    let theme: AppTheme
+    let favoriteTools: [ToolItem]
     let recentTools: [ToolItem]
-    @Binding var scrollToTopTrigger: Bool
-
-    let accent: AccentColorOption
-    let primary: Color
-    let colorScheme: ColorScheme
-
-    let onOpenTool: (ToolItem) -> Void
-    let onShowTools: () -> Void
-
-    @State private var showTopBorder = false
+    let allTools: [ToolItem]
+    let onSelectTool: (ToolItem) -> Void
+    let onShowAllTools: () -> Void
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 28) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .padding(.bottom, -24)
-                        .id("homeTop")
-
-                    heroCard
-                        .background(
-                            GeometryReader { geo -> Color in
-                                DispatchQueue.main.async {
-                                    let shouldShow = geo.frame(in: .named("homeScroll")).minY < 0
-                                    if showTopBorder != shouldShow {
-                                        withAnimation(.easeInOut(duration: 0.25)) {
-                                            showTopBorder = shouldShow
-                                        }
-                                    }
-                                }
-                                return Color.clear
-                            }
-                        )
-                        .padding(.horizontal, AppStyle.horizontalPadding)
-
-                    recentsSection
-
-                    Spacer(minLength: 60)
+        ScrollView {
+            VStack(spacing: 24) {
+                heroCard
+                if !favoriteTools.isEmpty {
+                    favoritesSection
                 }
+                recentsSection
             }
-            .coordinateSpace(name: "homeScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.45))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-            }
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    proxy.scrollTo("homeTop", anchor: .top)
-                }
-            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 28)
         }
+        .background(theme.background.ignoresSafeArea())
     }
 
     private var heroCard: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            HStack(alignment: .top) {
+        SurfaceCard(theme: theme) {
+            VStack(alignment: .leading, spacing: 16) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Welcome back")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.7))
-                    Text("Craft something brilliant today")
-                        .font(.system(size: 30, weight: .heavy, design: .rounded))
-                        .foregroundStyle(primary)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(theme.secondary)
+                    Text("Create something brilliant")
+                        .font(.title.weight(.heavy))
+                        .foregroundStyle(theme.foreground)
                 }
 
-                Spacer()
+                Text("Resonans keeps your creative utilities in one focused workspace. Jump into tools or pick up where you left off.")
+                    .font(.callout)
+                    .foregroundStyle(theme.tertiary)
 
-                VStack(spacing: 8) {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 26, weight: .bold))
-                        .foregroundStyle(accent.color)
-                    Text("v1.2")
-                        .font(.system(size: 12, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.6))
+                Button(action: onShowAllTools) {
+                    Label("Browse tools", systemImage: "wrench.and.screwdriver")
+                        .font(.headline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
                 }
+                .buttonStyle(.plain)
+                .background(theme.buttonBackground)
+                .foregroundStyle(theme.accentColor)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
             }
-
-            Button {
-                HapticsManager.shared.selection()
-                onShowTools()
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "wrench.and.screwdriver")
-                        .font(.system(size: 18, weight: .semibold))
-                    Text("Browse tools")
-                        .font(.system(size: 18, weight: .semibold, design: .rounded))
-                }
-                .foregroundStyle(accent.color)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-                .background(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.18))
-                .clipShape(RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
-                        .stroke(accent.color.opacity(0.35), lineWidth: 1)
-                )
-            }
-            .buttonStyle(.plain)
         }
-        .padding(AppStyle.innerPadding)
-        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .large)
+    }
+
+    private var favoritesSection: some View {
+        SurfaceCard(theme: theme) {
+            VStack(alignment: .leading, spacing: 16) {
+                header(title: "Favourites", subtitle: "Pinned utilities ready to launch")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 16) {
+                        ForEach(favoriteTools) { tool in
+                            ToolBadge(theme: theme, tool: tool) {
+                                onSelectTool(tool)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
     }
 
     private var recentsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Recently used")
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
-                Spacer()
-            }
-            .padding(.horizontal, AppStyle.horizontalPadding)
+        SurfaceCard(theme: theme) {
+            VStack(alignment: .leading, spacing: 16) {
+                header(title: "Recently used", subtitle: "Quick access to your latest tools")
 
-            if recentTools.isEmpty {
-                Text("Jump back into tools and your history will live here.")
-                    .font(.system(size: 15, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
-                    .padding(.horizontal, AppStyle.horizontalPadding)
-                    .padding(.vertical, 28)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                    .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                            )
-                    )
-                    .appShadow(colorScheme: colorScheme, level: .medium)
-                    .padding(.horizontal, AppStyle.horizontalPadding)
-            } else {
-                VStack(spacing: 12) {
-                    ForEach(recentTools) { tool in
-                        Button {
-                            HapticsManager.shared.selection()
-                            onOpenTool(tool)
-                        } label: {
-                            ToolHistoryRow(tool: tool, primary: primary, colorScheme: colorScheme)
+                if recentTools.isEmpty {
+                    Text("Launch a tool to see it appear here.")
+                        .font(.callout)
+                        .foregroundStyle(theme.tertiary)
+                        .padding(.vertical, 8)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(recentTools) { tool in
+                            Button {
+                                onSelectTool(tool)
+                            } label: {
+                                ToolRow(theme: theme, tool: tool)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                 }
-                .padding(.horizontal, AppStyle.horizontalPadding)
+
+                if !recentTools.isEmpty && recentTools.count < allTools.count {
+                    Button(action: onShowAllTools) {
+                        Label("View all tools", systemImage: "arrow.right")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(theme.accentColor)
+                    .padding(.top, 4)
+                }
             }
+        }
+    }
+
+    private func header(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(theme.foreground)
+            Text(subtitle)
+                .font(.footnote)
+                .foregroundStyle(theme.secondary)
         }
     }
 }
 
-private struct ToolHistoryRow: View {
+private struct ToolBadge: View {
+    let theme: AppTheme
     let tool: ToolItem
-    let primary: Color
-    let colorScheme: ColorScheme
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 10) {
+                Image(systemName: tool.iconName)
+                    .font(.title.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .padding(18)
+                    .background(
+                        LinearGradient(
+                            colors: tool.gradientColors,
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(tool.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(theme.foreground)
+                    Text(tool.subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(theme.tertiary)
+                        .lineLimit(2)
+                }
+            }
+            .frame(width: 180, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct ToolRow: View {
+    let theme: AppTheme
+    let tool: ToolItem
 
     var body: some View {
         HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: tool.gradientColors,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
                 )
+                .frame(width: 54, height: 54)
                 .overlay(
                     Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundColor(.white)
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(.white)
                 )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .font(.headline)
+                    .foregroundStyle(theme.foreground)
                 Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
+                    .font(.footnote)
+                    .foregroundStyle(theme.secondary)
                     .lineLimit(2)
             }
 
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(primary.opacity(0.4))
+                .foregroundStyle(theme.tertiary)
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(theme.subtleSurface)
         )
-        .appShadow(colorScheme: colorScheme, level: .small)
     }
 }
 
 #Preview {
-    struct PreviewWrapper: View {
-        @State private var trigger = false
-        let tools = ToolItem.all
-        var body: some View {
-            HomeDashboardView(
-                tools: tools,
-                recentTools: tools,
-                scrollToTopTrigger: $trigger,
-                accent: .purple,
-                primary: .black,
-                colorScheme: .light,
-                onOpenTool: { _ in },
-                onShowTools: {}
-            )
-        }
-    }
-    return PreviewWrapper()
+    HomeDashboardView(
+        theme: AppTheme(accent: .purple, colorScheme: .light),
+        favoriteTools: ToolItem.all,
+        recentTools: ToolItem.all,
+        allTools: ToolItem.all,
+        onSelectTool: { _ in },
+        onShowAllTools: {}
+    )
 }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -1,32 +1,24 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @Binding var scrollToTopTrigger: Bool
+    let theme: AppTheme
+    let onShowOnboarding: () -> Void
+
     @AppStorage("appearance") private var appearanceRaw = Appearance.system.rawValue
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
-
     @AppStorage("hapticsEnabled") private var hapticsEnabled = true
     @AppStorage("soundsEnabled") private var soundsEnabled = true
     @AppStorage("experimentalEnabled") private var experimentalEnabled = false
-    @State private var showTopBorder = false
 
-    private var appearance: Appearance {
-        Appearance(rawValue: appearanceRaw) ?? .system
-    }
-
-    private var accent: AccentColorOption {
-        AccentColorOption(rawValue: accentRaw) ?? .purple
-    }
     @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
 
-    private var primary: Color { AppStyle.primary(for: colorScheme) }
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     private var versionDisplayString: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
-        if let version = version, !version.isEmpty {
-            if let build = build, !build.isEmpty {
+        if let version, !version.isEmpty {
+            if let build, !build.isEmpty {
                 return "\(version) (\(build))"
             }
             return version
@@ -35,240 +27,110 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 24) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .padding(.bottom, -24)
-                        .id("top")
-                    appearanceSection
-                    otherSection
-                    aboutSection
-                    Spacer(minLength: 120)
+        List {
+            Section("Appearance") {
+                Picker("Appearance", selection: $appearanceRaw) {
+                    ForEach(Appearance.allCases) { mode in
+                        Text(mode.label).tag(mode.rawValue)
+                    }
                 }
-                .padding(.bottom, AppStyle.innerPadding)
-                .background(
-                    GeometryReader { geo -> Color in
-                        DispatchQueue.main.async {
-                            let show = geo.frame(in: .named("settingsScroll")).minY < -AppStyle.innerPadding
-                            if showTopBorder != show {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    showTopBorder = show
-                                }
+                .pickerStyle(.segmented)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Accent colour")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(theme.foreground)
+
+                    let columns = [GridItem(.adaptive(minimum: 36, maximum: 56))]
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(AccentColorOption.allCases) { option in
+                            Button {
+                                accentRaw = option.rawValue
+                                HapticsManager.shared.selection()
+                            } label: {
+                                Circle()
+                                    .fill(option.color)
+                                    .frame(width: 32, height: 32)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(
+                                                option == accent ? theme.accentColor : theme.border,
+                                                lineWidth: option == accent ? 3 : 1
+                                            )
+                                            .scaleEffect(option == accent ? 1.2 : 1)
+                                    )
+                                    .animation(.easeInOut(duration: 0.2), value: accentRaw)
                             }
-                        }
-                        return Color.clear
-                    }
-                )
-            }
-            .coordinateSpace(name: "settingsScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.5))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-            }
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation {
-                    proxy.scrollTo("top", anchor: .top)
-                }
-            }
-        }
-    }
-
-    // MARK: - Sections
-
-    private var appearanceSection: some View {
-        settingsBox {
-            Text("Appearance")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-
-            HStack(spacing: 12) {
-                ForEach(Appearance.allCases) { mode in
-                    VStack(spacing: 6) {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .inset(by: -4)
-                                .stroke(mode == appearance ? accent.color : .clear, lineWidth: 3)
-                                .scaleEffect(mode == appearance ? 1 : 0.9)
-                                .animation(.easeInOut(duration: 0.2), value: appearance)
-                            themePreview(for: mode)
-                                .transition(.opacity)
-                                .animation(.easeInOut(duration: 0.3), value: appearance)
-                        }
-                        .onTapGesture {
-                            HapticsManager.shared.pulse()
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                appearanceRaw = mode.rawValue
-                            }
-                        }
-                        Text(mode.label)
-                            .font(.system(size: 16, weight: .regular, design: .rounded))
-                            .foregroundStyle(primary.opacity(0.8))
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-            }
-            .padding(.top, 8)
-
-            Text("Accent color")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
-                .padding(.top, 20)
-
-            HStack(spacing: 16) {
-                ForEach(AccentColorOption.allCases) { option in
-                    ZStack {
-                        Circle()
-                            .stroke(primary, lineWidth: option == accent ? 3 : 0)
-                            .frame(width: 28, height: 28)
-                            .scaleEffect(option == accent ? 1.3 : 1.0)
-                            .animation(.easeInOut(duration: 0.25), value: accent)
-                        Circle()
-                            .fill(option.color)
-                            .frame(width: 28, height: 28)
-                    }
-                    .animation(.easeInOut(duration: 0.25), value: accent)
-                    .onTapGesture {
-                        HapticsManager.shared.pulse()
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            accentRaw = option.rawValue
+                            .buttonStyle(.plain)
                         }
                     }
                 }
+                .padding(.top, 4)
             }
-        }
-    }
+            .textCase(nil)
 
-    private var otherSection: some View {
-        settingsBox {
-            Text("Other")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
+            Section("Preferences") {
+                Toggle("Vibration", isOn: $hapticsEnabled)
+                    .onChange(of: hapticsEnabled) { _, _ in
+                        HapticsManager.shared.selection()
+                    }
 
-            Toggle(isOn: $hapticsEnabled) {
-                Text("Vibration")
-                    .foregroundStyle(primary.opacity(0.9))
+                Toggle("Sounds", isOn: $soundsEnabled)
+                    .onChange(of: soundsEnabled) { _, _ in
+                        HapticsManager.shared.selection()
+                    }
+
+                Toggle("Experimental features", isOn: $experimentalEnabled)
+                    .onChange(of: experimentalEnabled) { _, _ in
+                        HapticsManager.shared.selection()
+                    }
             }
-            .onChange(of: hapticsEnabled) { _, _ in
-                HapticsManager.shared.selection()
-            }
+            .textCase(nil)
 
-            Toggle(isOn: $soundsEnabled) {
-                Text("Sounds")
-                    .foregroundStyle(primary.opacity(0.9))
-            }
-            .onChange(of: soundsEnabled) { _, _ in
-                HapticsManager.shared.selection()
-            }
-
-            Toggle(isOn: $experimentalEnabled) {
-                Text("Experimental Features")
-                    .foregroundStyle(primary.opacity(0.9))
-            }
-            .onChange(of: experimentalEnabled) { _, _ in
-                HapticsManager.shared.selection()
-            }
-
-            Divider()
-                .padding(.vertical, 4)
-
-            Button {
-                CacheManager.shared.clear()
-                HapticsManager.shared.notify(.success)
-            } label: {
-                Text("Clear Cache")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(accent.color.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
-            }
-            .padding(.top, 4)
-        }
-    }
-
-    private var aboutSection: some View {
-        settingsBox {
-            Text("About")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
-
-            HStack {
-                Text("Version")
-                Spacer()
-                Text(versionDisplayString)
-            }
-            .foregroundStyle(primary.opacity(0.8))
-
-            Button {
-                HapticsManager.shared.pulse()
-                if let url = URL(string: "mailto:feedback.lian@gmail.com") {
-                    openURL(url)
+            Section("Utilities") {
+                Button {
+                    CacheManager.shared.clear()
+                    HapticsManager.shared.notify(.success)
+                } label: {
+                    Label("Clear cache", systemImage: "trash")
+                        .foregroundStyle(theme.foreground)
                 }
-            } label: {
-                Text("Send Feedback")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(accent.color.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.35)
             }
-            .padding(.top, 12)
-        }
-    }
+            .textCase(nil)
 
-    // MARK: - Helpers
+            Section("About") {
+                HStack {
+                    Text("Version")
+                    Spacer()
+                    Text(versionDisplayString)
+                        .foregroundStyle(theme.secondary)
+                }
 
-    @ViewBuilder
-    private func themePreview(for mode: Appearance) -> some View {
-        switch mode {
-        case .light:
-            Image("white")
-                .resizable()
-                .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
-        case .dark:
-            Image("dark")
-                .resizable()
-                .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
-        case .system:
-            Image("darkandwhite")
-                .resizable()
-                .scaledToFit()
-                .cornerRadius(12)
-                .transition(.opacity)
-        }
-    }
+                Button {
+                    if let url = URL(string: "mailto:feedback.lian@gmail.com") {
+                        openURL(url)
+                    }
+                } label: {
+                    Label("Send feedback", systemImage: "envelope")
+                        .foregroundStyle(theme.accentColor)
+                }
+            }
+            .textCase(nil)
 
-    private func settingsBox<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
-            content()
+            Section {
+                Button("View onboarding again", action: onShowOnboarding)
+                    .foregroundStyle(theme.accentColor)
+            }
         }
-        .padding(AppStyle.innerPadding)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .appCardStyle(
-            primary: primary,
-            colorScheme: colorScheme,
-            fillOpacity: AppStyle.subtleCardFillOpacity,
-            shadowLevel: .medium
-        )
-        .padding(.horizontal, AppStyle.horizontalPadding)
+        .listStyle(.insetGrouped)
+        .listRowSeparator(.hidden)
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
     }
 }
 
 #Preview {
-    SettingsView(scrollToTopTrigger: .constant(false))
-        .background(Color.black)
-        .preferredColorScheme(.dark)
+    NavigationStack {
+        SettingsView(theme: AppTheme(accent: .purple, colorScheme: .light)) {}
+    }
 }

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -1,192 +1,130 @@
 import SwiftUI
 
 struct ToolsView: View {
+    let theme: AppTheme
     let tools: [ToolItem]
-    @Binding var selectedTool: ToolItem.Identifier
-    @Binding var scrollToTopTrigger: Bool
+    @Binding var favorites: Set<ToolItem.Identifier>
+    let onSelectTool: (ToolItem) -> Void
 
-    let accent: AccentColorOption
-    let primary: Color
-    let colorScheme: ColorScheme
-    let activeTool: ToolItem.Identifier?
-    let onOpen: (ToolItem) -> Void
-    let onClose: (ToolItem.Identifier) -> Void
-
-    @State private var showTopBorder = false
+    private var favoriteTools: [ToolItem] {
+        tools.filter { favorites.contains($0.id) }
+    }
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical) {
-                VStack(spacing: 18) {
-                    Color.clear
-                        .frame(height: AppStyle.innerPadding)
-                        .id("toolsTop")
-
-                    ForEach(tools) { tool in
-                        ToolListRow(
-                            tool: tool,
-                            primary: primary,
-                            colorScheme: colorScheme,
-                            accent: accent.color,
-                            isSelected: tool.id == selectedTool,
-                            isOpen: activeTool == tool.id,
-                            onTap: {
-                                if selectedTool != tool.id {
-                                    withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                        selectedTool = tool.id
-                                    }
-                                }
-                                onOpen(tool)
-                            },
-                            onToggleOpenState: {
-                                if activeTool == tool.id {
-                                    onClose(tool.id)
-                                } else {
-                                    if selectedTool != tool.id {
-                                        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
-                                            selectedTool = tool.id
-                                        }
-                                    }
-                                    onOpen(tool)
-                                }
-                            }
-                        )
-                        .background(
-                            GeometryReader { geo -> Color in
-                                DispatchQueue.main.async {
-                                    let shouldShow = geo.frame(in: .named("toolsScroll")).minY < -24
-                                    if showTopBorder != shouldShow {
-                                        withAnimation(.easeInOut(duration: 0.2)) {
-                                            showTopBorder = shouldShow
-                                        }
-                                    }
-                                }
-                                return Color.clear
-                            }
-                        )
+        List {
+            if !favoriteTools.isEmpty {
+                Section("Favourites") {
+                    ForEach(favoriteTools) { tool in
+                        ToolRow(theme: theme, tool: tool, isFavourite: true) {
+                            onSelectTool(tool)
+                        } onToggleFavourite: {
+                            toggleFavourite(tool.id)
+                        }
+                        .listRowBackground(theme.surface)
                     }
+                }
+                .textCase(nil)
+            }
 
-                    Spacer(minLength: 80)
-                }
-                .padding(.horizontal, AppStyle.horizontalPadding)
-            }
-            .coordinateSpace(name: "toolsScroll")
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.45))
-                    .frame(height: 1)
-                    .opacity(showTopBorder ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.2), value: showTopBorder)
-            }
-            .onChange(of: scrollToTopTrigger) { _, _ in
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
-                    proxy.scrollTo("toolsTop", anchor: .top)
+            Section("All tools") {
+                ForEach(tools) { tool in
+                    ToolRow(
+                        theme: theme,
+                        tool: tool,
+                        isFavourite: favorites.contains(tool.id)
+                    ) {
+                        onSelectTool(tool)
+                    } onToggleFavourite: {
+                        toggleFavourite(tool.id)
+                    }
+                    .listRowBackground(theme.surface)
                 }
             }
+            .textCase(nil)
         }
-        .background(
-            .clear
-        )
+        .listStyle(.insetGrouped)
+        .listRowSeparator(.hidden)
+        .environment(\.defaultMinListRowHeight, 68)
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
+    }
+
+    private func toggleFavourite(_ identifier: ToolItem.Identifier) {
+        if favorites.contains(identifier) {
+            favorites.remove(identifier)
+        } else {
+            favorites.insert(identifier)
+        }
+        HapticsManager.shared.selection()
     }
 }
 
-private struct ToolListRow: View {
+private struct ToolRow: View {
+    let theme: AppTheme
     let tool: ToolItem
-    let primary: Color
-    let colorScheme: ColorScheme
-    let accent: Color
-    let isSelected: Bool
-    let isOpen: Bool
-    let onTap: () -> Void
-    let onToggleOpenState: () -> Void
+    let isFavourite: Bool
+    let onSelect: () -> Void
+    let onToggleFavourite: () -> Void
 
     var body: some View {
         HStack(spacing: 16) {
-            RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                .fill(LinearGradient(colors: tool.gradientColors, startPoint: .topLeading, endPoint: .bottomTrailing))
-                .frame(width: 52, height: 52)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
-                        .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: tool.gradientColors,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
                 )
+                .frame(width: 50, height: 50)
                 .overlay(
                     Image(systemName: tool.iconName)
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundStyle(Color.white)
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(.white)
                 )
-                .appShadow(colorScheme: colorScheme, level: .small, opacity: 0.45)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(tool.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
-
+                    .font(.headline)
+                    .foregroundStyle(theme.foreground)
                 Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.65))
+                    .font(.subheadline)
+                    .foregroundStyle(theme.secondary)
                     .lineLimit(2)
             }
 
             Spacer()
 
-            Button(action: {
-                HapticsManager.shared.pulse()
-                onToggleOpenState()
-            }) {
-                Image(systemName: isOpen ? "xmark" : "chevron.right")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(accent)
+            Button(action: onToggleFavourite) {
+                Image(systemName: isFavourite ? "heart.fill" : "heart")
+                    .foregroundStyle(isFavourite ? theme.accentColor : theme.tertiary)
             }
             .buttonStyle(.plain)
+
+            Image(systemName: "arrow.up.right.square")
+                .foregroundStyle(theme.accentColor)
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
-        .background(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .fill(primary.opacity(AppStyle.cardFillOpacity))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
-                )
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(
-                    accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
-                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
-                )
-        )
-        .appShadow(
-            colorScheme: colorScheme,
-            level: .medium,
-            opacity: (isOpen || isSelected) ? 0.6 : 0.4
-        )
+        .padding(.vertical, 8)
         .contentShape(Rectangle())
-        .onTapGesture {
-            HapticsManager.shared.selection()
-            onTap()
-        }
+        .onTapGesture(perform: onSelect)
     }
 }
 
 #Preview {
     struct PreviewWrapper: View {
-        @State private var selected = ToolItem.Identifier.audioExtractor
-        @State private var trigger = false
+        @State private var favourites: Set<ToolItem.Identifier> = [.audioExtractor]
 
         var body: some View {
-            ToolsView(
-                tools: ToolItem.all,
-                selectedTool: $selected,
-                scrollToTopTrigger: $trigger,
-                accent: .purple,
-                primary: .black,
-                colorScheme: .light,
-                activeTool: nil,
-                onOpen: { _ in },
-                onClose: { _ in }
-            )
+            NavigationStack {
+                ToolsView(
+                    theme: AppTheme(accent: .purple, colorScheme: .light),
+                    tools: ToolItem.all,
+                    favorites: $favourites,
+                    onSelectTool: { _ in }
+                )
+            }
         }
     }
+
     return PreviewWrapper()
 }


### PR DESCRIPTION
## Summary
- introduce a shared `AppTheme` helper and reusable `SurfaceCard` to keep colours and spacing consistent
- rebuild the home dashboard, tools list, settings, and audio extractor layouts around the new design system
- simplify `ContentView` navigation to a standard tab layout with sheet-based tool presentation

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e06f2570b48320a55da4af4dab4304