### PR TITLE
Restore tool closing behavior and add dummy tool

### DIFF
--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ToolItem: Identifiable {
     enum Identifier: String, Hashable {
         case audioExtractor
+        case dummy
     }
 
     let id: Identifier
@@ -24,7 +25,20 @@ struct ToolItem: Identifiable {
         destination: { onClose in AnyView(AudioExtractorView(onClose: onClose)) }
     )
 
+    static let dummy = ToolItem(
+        id: .dummy,
+        title: "Dummy Tool",
+        subtitle: "A placeholder tool to experiment with multiple tool layouts.",
+        iconName: "puzzlepiece.extension",
+        gradientColors: [
+            Color(red: 0.22, green: 0.72, blue: 0.99),
+            Color(red: 0.30, green: 0.52, blue: 0.94)
+        ],
+        destination: { onClose in AnyView(DummyToolView(onClose: onClose)) }
+    )
+
     static let all: [ToolItem] = [
-        .audioExtractor
+        .audioExtractor,
+        .dummy
     ]
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -385,6 +385,9 @@ struct ContentView: View {
                 selectedTab = .tools
             }
         }
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.78)) {
+            activeToolID = nil
+        }
     }
 
     private func updateRecents(with identifier: ToolItem.Identifier) {
@@ -401,6 +404,8 @@ struct ContentView: View {
         switch tool.id {
         case .audioExtractor:
             AudioExtractorView(onClose: { closeActiveTool() })
+        case .dummy:
+            DummyToolView(onClose: { closeActiveTool() })
         }
     }
 }

--- a/Resonans/Views/Tools/DummyToolView.swift
+++ b/Resonans/Views/Tools/DummyToolView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct DummyToolView: View {
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
+
+    init(onClose: @escaping () -> Void = {}) {
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 32) {
+                Color.clear
+                    .frame(height: AppStyle.innerPadding)
+                    .padding(.bottom, -24)
+
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Nothing to see here")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(primary)
+
+                    Text("This is just a placeholder view to help you test how multiple tools behave in the interface.")
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.7))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("Feel free to close this tool whenever you like—it's happy to step aside.")
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary.opacity(0.65))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, AppStyle.innerPadding)
+                .padding(.vertical, 28)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                        .fill(primary.opacity(AppStyle.subtleCardFillOpacity))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                        )
+                )
+                .appShadow(colorScheme: colorScheme, level: .medium)
+                .padding(.horizontal, AppStyle.horizontalPadding)
+
+                Button {
+                    HapticsManager.shared.selection()
+                    onClose()
+                } label: {
+                    Text("Close dummy tool")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .foregroundStyle(primary)
+                        .padding(.vertical, 18)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                .fill(primary.opacity(AppStyle.cardFillOpacity))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                        .stroke(primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .appShadow(colorScheme: colorScheme, level: .medium)
+                .padding(.horizontal, AppStyle.horizontalPadding)
+
+                Spacer(minLength: 80)
+            }
+        }
+        .background(.clear)
+    }
+}
+
+#Preview {
+    DummyToolView()
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -120,9 +120,9 @@ private struct ToolListRow: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(
+                .strokeBorder(
                     accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
-                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
+                    lineWidth: isOpen ? 2 : (isSelected ? 1.5 : 0)
                 )
         )
         .contentShape(Rectangle())


### PR DESCRIPTION
## Summary
- ensure closing a tool returns the user to the tools list and clears the active tool state
- match the tools list border styling with the rest of the app
- add a dummy tool for exercising multi-tool behaviours

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7e7a841608320a8c6bb90dc9cd45d