### PR TITLE
Restore tool closing behavior and add dummy tool

### DIFF
--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ToolItem: Identifiable {
     enum Identifier: String, Hashable {
         case audioExtractor
+        case dummy
     }
 
     let id: Identifier
@@ -24,7 +25,20 @@ struct ToolItem: Identifiable {
         destination: { onClose in AnyView(AudioExtractorView(onClose: onClose)) }
     )
 
+    static let dummy = ToolItem(
+        id: .dummy,
+        title: "Dummy",
+        subtitle: "A playful sandbox to test multi-tool interactions.",
+        iconName: "puzzlepiece.extension.fill",
+        gradientColors: [
+            Color(red: 0.98, green: 0.55, blue: 0.31),
+            Color(red: 0.99, green: 0.71, blue: 0.39)
+        ],
+        destination: { onClose in AnyView(DummyToolView(onClose: onClose)) }
+    )
+
     static let all: [ToolItem] = [
-        .audioExtractor
+        .audioExtractor,
+        .dummy
     ]
 }

--- a/Resonans/Views/ContentView.swift
+++ b/Resonans/Views/ContentView.swift
@@ -385,6 +385,9 @@ struct ContentView: View {
                 selectedTab = .tools
             }
         }
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.8)) {
+            activeToolID = nil
+        }
     }
 
     private func updateRecents(with identifier: ToolItem.Identifier) {
@@ -401,6 +404,8 @@ struct ContentView: View {
         switch tool.id {
         case .audioExtractor:
             AudioExtractorView(onClose: { closeActiveTool() })
+        case .dummy:
+            DummyToolView(onClose: { closeActiveTool() })
         }
     }
 }

--- a/Resonans/Views/Tools/DummyToolView.swift
+++ b/Resonans/Views/Tools/DummyToolView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct DummyToolView: View {
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
+
+    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+    private var primary: Color { AppStyle.primary(for: colorScheme) }
+
+    init(onClose: @escaping () -> Void = {}) {
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 28) {
+                Color.clear
+                    .frame(height: AppStyle.innerPadding)
+                    .padding(.bottom, -24)
+
+                header
+
+                descriptionCard
+
+                Spacer(minLength: 60)
+            }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+        }
+        .background(.clear)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Dummy Playground")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundStyle(primary.opacity(0.7))
+                Text("Experiment with tool navigation")
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .foregroundStyle(primary)
+            }
+
+            Spacer()
+
+            Image(systemName: "puzzlepiece.extension")
+                .font(.system(size: 30, weight: .bold))
+                .foregroundStyle(accent.color)
+        }
+    }
+
+    private var descriptionCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("This is a simple placeholder tool designed to help you test how the multi-tool flow behaves when several entries are available.")
+                .font(.system(size: 17, weight: .medium, design: .rounded))
+                .foregroundStyle(primary.opacity(0.8))
+
+            Text("Close the tool from the header or the list to return to the tool overview. Everything here is purely for demonstration purposes.")
+                .font(.system(size: 16, weight: .regular, design: .rounded))
+                .foregroundStyle(primary.opacity(0.7))
+        }
+        .padding(.horizontal, AppStyle.innerPadding)
+        .padding(.vertical, 24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .appCardStyle(primary: primary, colorScheme: colorScheme, shadowLevel: .medium)
+    }
+}
+
+#Preview {
+    DummyToolView()
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -120,10 +120,13 @@ private struct ToolListRow: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                .stroke(
-                    accent.opacity(isOpen ? 0.65 : (isSelected ? 0.45 : 0)),
-                    lineWidth: isOpen ? 3 : (isSelected ? 2 : 0)
+                .strokeBorder(
+                    primary.opacity(
+                        isOpen ? AppStyle.strokeOpacity * 1.8 : (isSelected ? AppStyle.strokeOpacity * 1.4 : AppStyle.strokeOpacity)
+                    ),
+                    lineWidth: isOpen ? 2 : 1
                 )
+                .opacity(isOpen || isSelected ? 1 : 0)
         )
         .contentShape(Rectangle())
         .onTapGesture {


### PR DESCRIPTION
## Summary
- reset the active tool when closing so the tools tab reappears after exiting
- align the tool list border styling with the rest of the app
- add a dummy tool view so the multi-tool experience can be tested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7e7a841608320a8c6bb90dc9cd45d