### PR TITLE
refactor(content-view): transferring business logics to view model

### DIFF
--- a/Resonans/ResonansApp.swift
+++ b/Resonans/ResonansApp.swift
@@ -14,7 +14,7 @@ struct ResonansApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(viewModel: ContentViewModel())
                 .preferredColorScheme(appearance.colorScheme)
                 .animation(.easeInOut(duration: 0.4), value: appearanceRaw)
         }

--- a/Resonans/Views/ContentView/ContentViewModel.swift
+++ b/Resonans/Views/ContentView/ContentViewModel.swift
@@ -5,7 +5,9 @@
 //  Created by Kevin Dallian on 10/10/25.
 //
 
+import Combine
 import Foundation
+import SwiftUI
 
 final class ContentViewModel: ObservableObject {
     @Published var homeScrollTrigger: Bool = false
@@ -15,14 +17,98 @@ final class ContentViewModel: ObservableObject {
     
     @Published var selectedTab: TabSelection = .home
     @Published var selectedTool: ToolItem.Identifier? = nil
+    @Published var showToolCloseIcon: Bool = false
+    @Published var shouldSkipCloseReset: Bool = false
+    
     var favoriteToolIds: Set<ToolItem.Identifier> = []
     var recentToolIDs: [ToolItem.Identifier] = []
     /// Used for tracking selectedTab before navigate to singluar tool tab
     var previousSelectedTab: TabSelection?
     
     let tools = ToolItem.all
+    let hapticsManager = HapticsManager.shared
+    let cacheManager = CacheManager.shared
+    
     var recentTools: [ToolItem] {
         recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
+    }
+    
+    func closeActiveTool() {
+        guard let identifier = selectedTool else { return }
+        let spring = Animation.spring(response: 0.45, dampingFraction: 0.8)
+
+        withAnimation(spring) {
+            showToolCloseIcon = false
+            shouldSkipCloseReset = false
+
+            if case let .tool(current) = selectedTab, current == identifier {
+                selectedTab = previousSelectedTab ?? .home
+            }
+
+            selectedTool = nil
+        }
+    }
+    
+    func launchTool(_ tool: ToolItem) {
+        let spring = Animation.spring(response: 0.5, dampingFraction: 0.78)
+        updateRecentTools(with: tool.id)
+        withAnimation(spring) {
+            selectedTool = tool.id
+            selectedTab = .tool(tool.id)
+        }
+        showToolCloseIcon = false
+        shouldSkipCloseReset = false
+    }
+    
+    func updateRecentTools(with identifier: ToolItem.Identifier) {
+        recentToolIDs.removeAll(where: { $0 == identifier })
+        recentToolIDs.insert(identifier, at: 0)
+        if recentToolIDs.count > 6 {
+            recentToolIDs = Array(recentToolIDs.prefix(6))
+        }
+        cacheManager.saveRecentTools(recentToolIDs)
+    }
+    
+    func tabBarButtonAction(tab: TabSelection, trigger: Binding<Bool>) {
+        let spring = Animation.spring(response: 0.45, dampingFraction: 0.8)
+        if selectedTab == tab {
+            trigger.wrappedValue.toggle()
+        } else {
+            withAnimation(spring) {
+                selectedTab = tab
+            }
+        }
+        if showToolCloseIcon {
+            withAnimation(spring) {
+                showToolCloseIcon = false
+            }
+        }
+        shouldSkipCloseReset = false
+    }
+    
+    func toolButtonAction(isSelected: Bool, identifier: ToolItem.Identifier) {
+        let spring = Animation.spring(response: 0.45, dampingFraction: 0.8)
+        if isSelected {
+            withAnimation(spring) {
+                showToolCloseIcon = true
+            }
+            shouldSkipCloseReset = true
+        } else {
+            withAnimation(spring) {
+                selectedTab = .tool(identifier)
+            }
+            if showToolCloseIcon {
+                hideToolCloseIcon()
+            }
+            shouldSkipCloseReset = false
+        }
+    }
+    
+    func hideToolCloseIcon() {
+        guard showToolCloseIcon else { return }
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.75)) {
+            showToolCloseIcon = false
+        }
     }
     
 }

--- a/Resonans/Views/ContentView/ContentViewModel.swift
+++ b/Resonans/Views/ContentView/ContentViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  ContentViewModel.swift
+//  Resonans
+//
+//  Created by Kevin Dallian on 10/10/25.
+//
+
+import Foundation
+
+final class ContentViewModel: ObservableObject {
+    @Published var homeScrollTrigger: Bool = false
+    @Published var toolsScrollTrigger: Bool = false
+    @Published var settingsScrollTrigger: Bool = false
+    @Published var showOnboarding: Bool = false
+    
+    @Published var selectedTab: TabSelection = .home
+    @Published var selectedTool: ToolItem.Identifier? = nil
+    var favoriteToolIds: Set<ToolItem.Identifier> = []
+    var recentToolIDs: [ToolItem.Identifier] = []
+    /// Used for tracking selectedTab before navigate to singluar tool tab
+    var previousSelectedTab: TabSelection?
+    
+    let tools = ToolItem.all
+    var recentTools: [ToolItem] {
+        recentToolIDs.compactMap { id in tools.first(where: { $0.id == id }) }
+    }
+    
+}
+
+enum TabSelection: Hashable {
+    case home
+    case tools
+    case settings
+    case tool(ToolItem.Identifier)
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ToolsView: View {
     let tools: [ToolItem]
-    @Binding var selectedTool: ToolItem.Identifier
+    @Binding var selectedTool: ToolItem.Identifier?
     @Binding var scrollToTopTrigger: Bool
 
     let accent: AccentColorOption
@@ -138,7 +138,7 @@ private struct ToolListRow: View {
 
 #Preview {
     struct PreviewWrapper: View {
-        @State private var selected = ToolItem.Identifier.audioExtractor
+        @State private var selected: ToolItem.Identifier? = ToolItem.Identifier.audioExtractor
         @State private var trigger = false
 
         var body: some View {


### PR DESCRIPTION
This PR refactors ContentView by moving state and behavioral logic into a dedicated ContentViewModel.
The goal is to improve separation of concerns and readability by keeping the SwiftUI view purely declarative while consolidating interaction logic (animations, tab changes, tool actions) inside the view model.