### PR TITLE
Implement spring morph transition for tool detail overlay

### DIFF
--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -12,6 +12,11 @@ struct ContentView: View {
     @available(*, deprecated)
     private var primary: Color { AppStyle.primary(for: colorScheme) }
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+    @State private var morphContext: ToolMorphContext?
+    @State private var morphProgress: CGFloat = 0
+    @State private var isMorphClosing = false
+
+    private var morphingToolID: ToolItem.Identifier? { morphContext?.tool.id }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -48,6 +53,11 @@ struct ContentView: View {
             }
             viewModel.previousSelectedTab = oldValue
         }
+        .onChange(of: viewModel.selectedTool) { _, newValue in
+            if newValue == nil {
+                dismissMorph(triggerToolClose: false)
+            }
+        }
         .simultaneousGesture(
             TapGesture().onEnded {
                 guard viewModel.showToolCloseIcon else { return }
@@ -74,11 +84,24 @@ struct ContentView: View {
     }
 
     private var mainContent: some View {
-        VStack(spacing: 0) {
-            header
-            ZStack {
-                tabs
-                tabBarOverlay
+        ZStack {
+            VStack(spacing: 0) {
+                header
+                ZStack {
+                    tabs
+                    tabBarOverlay
+                }
+            }
+
+            if let context = morphContext {
+                ToolMorphOverlay(
+                    context: context,
+                    progress: $morphProgress,
+                    detail: { toolView(for: context.tool) },
+                    onClose: { _ in dismissMorph() }
+                )
+                .zIndex(1)
+                .allowsHitTesting(true)
             }
         }
     }
@@ -101,6 +124,8 @@ struct ContentView: View {
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .animation(.easeInOut(duration: 0.3), value: viewModel.selectedTab)
+        .allowsHitTesting(morphContext == nil)
+        .blur(radius: morphProgress * 6)
     }
 
     private var tabBarOverlay: some View {
@@ -130,8 +155,20 @@ struct ContentView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 32, style: .continuous)
+                .fill(Color.black.opacity(0.18 * morphProgress))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 32, style: .continuous)
+                        .stroke(Color.white.opacity(0.08 * morphProgress), lineWidth: morphProgress > 0 ? 1 : 0)
+                )
+                .opacity(morphProgress)
+        )
         .padding(.horizontal, 40)
+        .blur(radius: morphProgress * 9)
+        .opacity(1 - 0.12 * morphProgress)
         .animation(.spring(response: 0.45, dampingFraction: 0.8), value: viewModel.selectedTool)
+        .animation(.easeInOut(duration: 0.2), value: morphProgress)
     }
 
     private var header: some View {
@@ -154,18 +191,7 @@ struct ContentView: View {
     private var headerActionButton: some View {
         switch viewModel.selectedTab {
         case .tool:
-            if viewModel.selectedTool != nil {
-                Button(action: {
-                    HapticsManager.shared.selection()
-                    viewModel.closeActiveTool()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .shadow(ShadowConfiguration.textConfiguration(for: colorScheme))
-                }
-                .buttonStyle(.plain)
-            }
+            EmptyView()
         case .settings:
             Button(action: {
                 HapticsManager.shared.pulse()
@@ -226,9 +252,12 @@ struct ContentView: View {
             },
             onClose: { identifier in
                 if viewModel.selectedTool == identifier {
-                    viewModel.closeActiveTool()
+                    dismissMorph()
                 }
-            }
+            },
+            morphingToolID: morphingToolID,
+            morphProgress: morphProgress,
+            onRequestMorph: handleMorphRequest
         )
     }
 
@@ -270,38 +299,19 @@ struct ContentView: View {
         } else {
             isSelected = false
         }
-        return Group {
-            if viewModel.showToolCloseIcon {
-                Button {
-                    HapticsManager.shared.pulse()
-                    viewModel.closeActiveTool()
-                } label: {
-                    symbolIcon(
-                        name: "xmark.square.fill",
-                        size: 24,
-                        weight: .semibold,
-                        color: accent.color
-                    )
-                }
-                .buttonStyle(.plain)
-                .animation(.spring(response: 0.45, dampingFraction: 0.75), value: viewModel.showToolCloseIcon)
-            } else {
-                Button {
-                    HapticsManager.shared.pulse()
-                    viewModel.toolButtonAction(isSelected: isSelected, identifier: identifier)
-                } label: {
-                    symbolIcon(
-                        name: "arrow.up.right.square.fill",
-                        size: 24,
-                        weight: .semibold,
-                        color: isSelected ? accent.color : primary.opacity(0.5)
-                    )
-                }
-                .buttonStyle(.plain)
-                .animation(.spring(response: 0.45, dampingFraction: 0.75), value: viewModel.showToolCloseIcon)
-                .animation(.easeInOut(duration: 0.25), value: viewModel.selectedTab)
-            }
+        return Button {
+            HapticsManager.shared.pulse()
+            viewModel.toolButtonAction(isSelected: isSelected, identifier: identifier)
+        } label: {
+            symbolIcon(
+                name: "arrow.up.right.square.fill",
+                size: 24,
+                weight: .semibold,
+                color: isSelected ? accent.color : primary.opacity(0.5)
+            )
         }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.selectedTab)
     }
 
     @ViewBuilder
@@ -311,6 +321,45 @@ struct ContentView: View {
             AudioExtractorView(onClose: { viewModel.closeActiveTool() })
         case .dummy:
             DummyToolView(onClose: { viewModel.closeActiveTool() })
+        }
+    }
+}
+
+private extension ContentView {
+    func handleMorphRequest(for tool: ToolItem, frame: CGRect) -> Bool {
+        guard morphContext == nil, !isMorphClosing else { return false }
+        morphContext = ToolMorphContext(tool: tool, originFrame: frame)
+        morphProgress = 0
+        isMorphClosing = false
+
+        DispatchQueue.main.async {
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.78, blendDuration: 0.2)) {
+                morphProgress = 1
+            }
+        }
+        return true
+    }
+
+    func dismissMorph(triggerToolClose: Bool = true) {
+        guard let context = morphContext, !isMorphClosing else { return }
+        isMorphClosing = true
+
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.8, blendDuration: 0.2)) {
+            morphProgress = 0
+        }
+
+        let activeTool = context.tool
+        let closeDelay = 0.55
+        DispatchQueue.main.asyncAfter(deadline: .now() + closeDelay) {
+            if triggerToolClose {
+                viewModel.closeActiveTool()
+            }
+
+            if morphContext?.tool.id == activeTool.id {
+                morphContext = nil
+            }
+
+            isMorphClosing = false
         }
     }
 }

--- a/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
+++ b/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
@@ -5,10 +5,13 @@ import SwiftUI
 
 struct ToolOverview: View {
     private let tool: ToolItem
-    init(tool:  ToolItem){
+    private let morphProgress: CGFloat
+
+    init(tool: ToolItem, morphProgress: CGFloat = 0) {
         self.tool = tool
+        self.morphProgress = morphProgress
     }
-    
+
     var body: some View {
         AppCard{
             HStack{
@@ -17,14 +20,31 @@ struct ToolOverview: View {
                     Text(tool.title)
                         .font(.system(size: 18, weight: .semibold, design: .rounded))
                         .foregroundStyle(.primary)
+                        .opacity(textOpacity)
+                        .blur(radius: textBlur)
 
                     Text(tool.subtitle)
                         .font(.system(size: 13, weight: .medium, design: .rounded))
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
+                        .opacity(textOpacity)
+                        .blur(radius: textBlur)
                 }
             }
         }
+        .opacity(cardOpacity)
+    }
+
+    private var textOpacity: CGFloat {
+        max(0, 1 - morphProgress * 1.2)
+    }
+
+    private var textBlur: CGFloat {
+        morphProgress * 8
+    }
+
+    private var cardOpacity: Double {
+        Double(max(0, 1 - morphProgress))
     }
 }
 

--- a/Resonans/Views/Tools/ToolMorphOverlay.swift
+++ b/Resonans/Views/Tools/ToolMorphOverlay.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+struct ToolMorphContext: Identifiable, Equatable {
+    let tool: ToolItem
+    let originFrame: CGRect
+
+    var id: ToolItem.Identifier { tool.id }
+}
+
+struct ToolMorphOverlay<Detail: View>: View {
+    let context: ToolMorphContext
+    @Binding var progress: CGFloat
+
+    private let detailContent: Detail
+    private let onClose: (ToolItem) -> Void
+
+    @State private var isClosing = false
+
+    init(
+        context: ToolMorphContext,
+        progress: Binding<CGFloat>,
+        @ViewBuilder detail: () -> Detail,
+        onClose: @escaping (ToolItem) -> Void
+    ) {
+        self.context = context
+        self._progress = progress
+        self.detailContent = detail()
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let screenRect = proxy.frame(in: .global)
+            let startRect = normalizedStartRect(within: screenRect)
+            let targetRect = screenRect
+            let currentRect = interpolatedRect(from: startRect, to: targetRect, progress: progress)
+            let currentCorner = cornerRadius(for: progress)
+
+            ZStack(alignment: .topLeading) {
+                Color.black.opacity(0.26 * progress)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+
+                RoundedRectangle(cornerRadius: currentCorner, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: currentCorner, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.14 * (1 - progress)), lineWidth: strokeWidth(for: progress))
+                    )
+                    .frame(width: currentRect.width, height: currentRect.height)
+                    .position(
+                        x: currentRect.midX - screenRect.minX,
+                        y: currentRect.midY - screenRect.minY
+                    )
+                    .shadow(color: Color.black.opacity(0.22 * progress), radius: 28 * progress, x: 0, y: 24 * progress)
+                    .overlay(
+                        containerContent(proxy: proxy, cornerRadius: currentCorner)
+                            .frame(width: currentRect.width, height: currentRect.height)
+                            .clipShape(RoundedRectangle(cornerRadius: currentCorner, style: .continuous))
+                            .position(
+                                x: currentRect.midX - screenRect.minX,
+                                y: currentRect.midY - screenRect.minY
+                            )
+                    )
+            }
+            .ignoresSafeArea()
+        }
+        .transition(.identity)
+    }
+
+    private func containerContent(proxy: GeometryProxy, cornerRadius: CGFloat) -> some View {
+        ZStack(alignment: .top) {
+            ToolOverview(tool: context.tool, morphProgress: min(1, progress * 1.15))
+                .opacity(max(0, 1 - progress * 1.8))
+                .blur(radius: progress * 12)
+
+            VStack(spacing: 0) {
+                detailContent
+                    .padding(.top, proxy.safeAreaInsets.top + 20)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 0)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .opacity(progress)
+                    .blur(radius: (1 - progress) * 18)
+                    .allowsHitTesting(progress > 0.95)
+
+                Spacer(minLength: 0)
+
+                closePill
+                    .padding(.horizontal, 64)
+                    .padding(.bottom, proxy.safeAreaInsets.bottom + 28)
+                    .opacity(progress)
+                    .allowsHitTesting(true)
+            }
+        }
+    }
+
+    private var closePill: some View {
+        Capsule()
+            .fill(.ultraThinMaterial)
+            .overlay(
+                HStack(spacing: 12) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text("Close Tool")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+                .foregroundStyle(Color.primary.opacity(0.9))
+            )
+            .shadow(color: Color.black.opacity(0.2 * progress), radius: 20 * progress, x: 0, y: 12 * progress)
+            .scaleEffect(0.92 + 0.08 * progress)
+            .gesture(dragGesture)
+            .accessibilityLabel(Text("Close tool"))
+            .allowsHitTesting(progress > 0.8)
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 6, coordinateSpace: .global)
+            .onChanged { value in
+                guard !isClosing else { return }
+                let normalized = closeProgress(for: value.translation)
+                progress = max(0, min(1, 1 - normalized))
+            }
+            .onEnded { value in
+                guard !isClosing else { return }
+                let normalized = closeProgress(for: value.translation)
+                if normalized > 0.45 {
+                    triggerClose()
+                } else {
+                    withAnimation(.spring(response: 0.5, dampingFraction: 0.82, blendDuration: 0.2)) {
+                        progress = 1
+                    }
+                }
+            }
+    }
+
+    private func triggerClose() {
+        guard !isClosing else { return }
+        isClosing = true
+        onClose(context.tool)
+    }
+
+    private func normalizedStartRect(within screenRect: CGRect) -> CGRect {
+        let base = context.originFrame
+        guard base != .zero else {
+            let width = min(screenRect.width * 0.8, 340)
+            let height = width * 0.62
+            return CGRect(
+                x: screenRect.midX - width / 2,
+                y: screenRect.midY - height / 2,
+                width: width,
+                height: height
+            )
+        }
+        return clamp(rect: base, within: screenRect)
+    }
+
+    private func interpolatedRect(from start: CGRect, to end: CGRect, progress: CGFloat) -> CGRect {
+        let clamped = max(0, min(1, progress))
+        let originX = start.minX + (end.minX - start.minX) * clamped
+        let originY = start.minY + (end.minY - start.minY) * clamped
+        let width = start.width + (end.width - start.width) * clamped
+        let height = start.height + (end.height - start.height) * clamped
+        return CGRect(x: originX, y: originY, width: width, height: height)
+    }
+
+    private func clamp(rect: CGRect, within bounds: CGRect) -> CGRect {
+        var rect = rect
+        if rect.width > bounds.width { rect.size.width = bounds.width }
+        if rect.height > bounds.height { rect.size.height = bounds.height }
+        rect.origin.x = max(bounds.minX, min(rect.minX, bounds.maxX - rect.width))
+        rect.origin.y = max(bounds.minY, min(rect.minY, bounds.maxY - rect.height))
+        return rect
+    }
+
+    private func cornerRadius(for progress: CGFloat) -> CGFloat {
+        let collapsedCorner: CGFloat = 30
+        let expandedCorner: CGFloat = 0
+        return collapsedCorner + (expandedCorner - collapsedCorner) * progress
+    }
+
+    private func strokeWidth(for progress: CGFloat) -> CGFloat {
+        let base: CGFloat = 1.0
+        return max(0.4, base * (1 - progress))
+    }
+
+    private func closeProgress(for translation: CGSize) -> CGFloat {
+        let vertical = max(0, -translation.height)
+        let horizontal = abs(translation.width)
+        let combined = vertical + horizontal * 0.7
+        let normalized = combined / 160
+        return max(0, min(1, normalized))
+    }
+}


### PR DESCRIPTION
## Summary
- add a ToolMorphOverlay that expands a tapped tool card into a full-screen spring animated detail view with an interactive close pill
- update ToolsView to request the morph animation, blur and fade the selected card’s text, and measure card frames for the transition
- integrate the overlay in ContentView so the TabView/TabBar blur while the tool animates, and route close requests through the morph dismissal

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68ed24fd15a88320ae0e92352fb4ad54