### PR TITLE
Introduce Typography for Centralized Font System

### DIFF
--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -13,8 +13,7 @@ struct RecentRow: View {
                 .frame(width: 48, height: 48)
                 .overlay(
                     Image(systemName: "waveform")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(.primary.opacity(0.9))
+                        .typography(.titleMedium, color: .primary.opacity(0.9))
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: AppStyle.iconCornerRadius, style: .continuous)
@@ -24,20 +23,17 @@ struct RecentRow: View {
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.titleMedium, color: .primary, design: .rounded)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Text(item.duration)
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundStyle(.primary.opacity(0.8))
+                    .typography(.caption, color: .primary.opacity(0.8))
             }
             Spacer()
             HStack(spacing: 10) {
                 ShareLink(item: item.fileURL) {
                     Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(.primary.opacity(0.9))
+                        .typography(.titleMedium, color: .primary.opacity(0.9))
                 }
                 .simultaneousGesture(TapGesture().onEnded {
                     HapticsManager.shared.selection()
@@ -48,8 +44,7 @@ struct RecentRow: View {
                     onSave(item)
                 }) {
                     Image(systemName: "tray.and.arrow.down")
-                        .font(.system(size: 22, weight: .bold))
-                        .foregroundStyle(.primary)
+                        .typography(.custom(size: 22, weight: .bold))
                 }
                 .buttonStyle(.plain)
             }

--- a/Resonans/Components/ToolIconView.swift
+++ b/Resonans/Components/ToolIconView.swift
@@ -57,8 +57,7 @@ struct ToolIconView: View {
             )
             .overlay(
                 Image(systemName: tool.iconName)
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundStyle(Color.white)
+                    .typography(.custom(size: 24, weight: .bold), color: .white)
             )
             .shadow(ShadowConfiguration.smallConfiguration(for: colorScheme))
     }

--- a/Resonans/Utilities/Typography.swift
+++ b/Resonans/Utilities/Typography.swift
@@ -1,0 +1,152 @@
+//
+//  Font.swift
+//  Resonans
+//
+//  Created by Kevin Dallian on 15/10/25.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Typography System
+/// `Typography` defines a reusable, centralized set of text styles
+/// used throughout the app. Each case represents a typographic role
+/// (e.g., display, title, body, caption) that encodes both size and weight.
+///
+/// ## Core Concept
+/// Instead of scattering `.font(.system(size:weight:))` across views,
+/// this enum provides a single source of truth for consistent typography.
+/// Designers and developers can update text hierarchy in one place.
+///
+/// ## Implementation
+/// Apply these styles in SwiftUI using the custom `typography(_:)`
+/// view modifier. Example:
+///
+/// ```swift
+/// Text("Welcome Back")
+///     .typography(.titleLarge)
+/// ```
+///
+/// You can also specify a custom text color:
+///
+/// ```swift
+/// Text("Tap to continue")
+///     .typography(.caption, color: .secondary)
+/// ```
+enum Typography {
+    /// Display Styles
+    case displayLarge
+    case displayMedium
+    case displaySmall
+    
+    /// Title Styles
+    case titleLarge
+    case titleMedium
+    case titleSmall
+    
+    /// Text Styles
+    case body
+    case callout
+    case caption
+    
+    /// Emphasis Variants
+    case bodyBold
+    case captionBold
+    
+    /// Custom cases
+    /// - Parameters:
+    ///   - size: The custom font size in points.
+    ///   - weight: The desired font weight (e.g., `.regular`, `.bold`).
+    case custom(size: CGFloat, weight: Font.Weight)
+    
+    // MARK: - Font Size
+    /// Defines the base point size for each text style.
+    /// Sizes are inspired by Apple’s Human Interface Guidelines (HIG).
+    var size: CGFloat {
+        switch self {
+        case .displayLarge: 40
+        case .displayMedium: 34
+        case .displaySmall: 28
+        case .titleLarge: 22
+        case .titleMedium: 20
+        case .titleSmall: 17
+        case .body, .bodyBold: 17
+        case .callout: 16
+        case .caption, .captionBold: 13
+        case .custom(let size, _): size
+        }
+    }
+    
+    // MARK: - Font Weight
+    /// Each typography case maps to an appropriate font weight
+    /// to visually communicate hierarchy and emphasis.
+    var weight: Font.Weight {
+        switch self {
+        case .displayLarge, .displayMedium, .displaySmall:
+            return .bold
+        case .titleLarge, .titleMedium:
+            return .semibold
+        case .titleSmall:
+            return .medium
+        case .body:
+            return .regular
+        case .bodyBold:
+            return .semibold
+        case .callout:
+            return .regular
+        case .caption:
+            return .regular
+        case .captionBold:
+            return .semibold
+        case .custom(_, let weight):
+            return weight
+        }
+    }
+    
+    // MARK: - Computed Font
+    /// Combines size, weight, and design into a reusable `Font` instance.
+    var font: Font {
+        .system(size: size, weight: weight, design: .default)
+    }
+}
+
+// MARK: - Typography Modifier
+/// `TypographyViewModifier` applies a predefined `Typography` style
+/// and color to any SwiftUI `View` (typically `Text`).
+///
+/// This modifier encapsulates all font styling logic,
+/// keeping the main view code declarative and clean.
+struct TypographyViewModifier: ViewModifier {
+    let typography: Typography
+    let color: Color
+    let design: Font.Design
+    
+    init(typography: Typography, color: Color, design: Font.Design) {
+        self.typography = typography
+        self.color = color
+        self.design = design
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .font(typography.font)
+            .foregroundStyle(color)
+    }
+}
+
+// MARK: - View Extension
+/// A convenience extension to apply `Typography` styles succinctly.
+///
+/// ### Example
+/// ```swift
+/// Text("Settings")
+///     .typography(.titleMedium)
+///
+/// Text("Version 1.0.0")
+///     .typography(.caption, color: .secondary)
+/// ```
+extension View {
+    func typography(_ typography: Typography, color: Color = .primary, design: Font.Design = .default) -> some View {
+        self.modifier(TypographyViewModifier(typography: typography, color: color, design: design))
+    }
+}

--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -10,7 +10,6 @@ struct ContentView: View {
     @Environment(\.colorScheme) private var colorScheme
     
     private var background: Color { AppStyle.background(for: colorScheme) }
-    
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     var body: some View {

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -18,22 +18,19 @@ struct HomeDashboardView: View {
                             HStack(alignment: .top) {
                                 VStack(alignment: .leading, spacing: 6) {
                                     Text("Welcome back")
-                                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                                        .typography(.custom(size: 16, weight: .semibold), color: primary.opacity(0.7), design: .rounded)
                                         .foregroundStyle(primary.opacity(0.7))
                                     Text("Craft something brilliant today")
-                                        .font(.system(size: 30, weight: .heavy, design: .rounded))
-                                        .foregroundStyle(primary)
+                                        .typography(.custom(size: 30, weight: .heavy), color: primary, design: .rounded)
                                 }
                                 
                                 Spacer()
                                 
                                 VStack(spacing: 8) {
                                     Image(systemName: "sparkles")
-                                        .font(.system(size: 26, weight: .bold))
-                                        .foregroundStyle(accent.color)
+                                        .typography(.custom(size: 26, weight: .bold), color: accent.color)
                                     Text("v1.2")
-                                        .font(.system(size: 12, weight: .medium, design: .rounded))
-                                        .foregroundStyle(primary.opacity(0.6))
+                                        .typography(.caption, color: primary.opacity(0.6), design: .rounded)
                                 }
                             }
                             
@@ -43,9 +40,9 @@ struct HomeDashboardView: View {
                             } label: {
                                 HStack(spacing: 12) {
                                     Image(systemName: "wrench.and.screwdriver")
-                                        .font(.system(size: 18, weight: .semibold))
+                                        .typography(.custom(size: 18, weight: .semibold))
                                     Text("Browse tools")
-                                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                                        .typography(.titleSmall, design: .rounded)
                                 }
                                 .foregroundStyle(accent.color)
                                 .frame(maxWidth: .infinity)
@@ -66,8 +63,7 @@ struct HomeDashboardView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
                             Text("Recently used")
-                                .font(.system(size: 24, weight: .bold, design: .rounded))
-                                .foregroundStyle(primary)
+                                .typography(.titleLarge, color: primary, design: .rounded)
                             Spacer()
                         }
                         .padding(.horizontal, AppStyle.horizontalPadding)
@@ -75,8 +71,7 @@ struct HomeDashboardView: View {
                         if viewModel.recentTools.isEmpty {
                             AppCard{
                                 Text("Jump back into tools and your history will live here.")
-                                    .font(.system(size: 15, weight: .medium, design: .rounded))
-                                    .foregroundStyle(primary.opacity(0.65))
+                                    .typography(.body, color: primary.opacity(0.65), design: .rounded)
                                     .frame(maxWidth: .infinity)
                             }
                             .padding(.horizontal, AppStyle.horizontalPadding)

--- a/Resonans/Views/OnboardingView.swift
+++ b/Resonans/Views/OnboardingView.swift
@@ -77,18 +77,15 @@ struct OnboardingFlowView: View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Welcome to Resonans")
-                    .font(.system(size: 22, weight: .bold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .typography(.titleLarge, color: primary, design: .rounded)
                 Text(stepSubtitle)
-                    .font(.system(size: 15, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
+                    .typography(.body, color: primary.opacity(0.7), design: .rounded)
             }
             Spacer()
             Button("Skip") {
                 finish()
             }
-            .font(.system(size: 15, weight: .semibold, design: .rounded))
-            .foregroundStyle(primary.opacity(0.8))
+            .typography(.captionBold, color: primary.opacity(0.8), design: .rounded)
         }
     }
 
@@ -107,15 +104,12 @@ struct OnboardingFlowView: View {
 
                 VStack(spacing: 18) {
                     Image(systemName: "waveform.circle.fill")
-                        .font(.system(size: 64, weight: .bold))
-                        .foregroundStyle(accent)
+                        .typography(.custom(size: 64, weight: .bold), color: accent)
                     Text("One workspace for every creative routine")
-                        .font(.system(size: 22, weight: .bold, design: .rounded))
-                        .foregroundStyle(primary)
+                        .typography(.titleLarge, color: primary, design: .rounded)
                         .multilineTextAlignment(.center)
                     Text("Resonans keeps all of your media tools organised. Pin favourites, pick up where you left off and stay in the loop with app news.")
-                        .font(.system(size: 15, weight: .medium, design: .rounded))
-                        .foregroundStyle(primary.opacity(0.75))
+                        .typography(.caption, color: primary.opacity(0.75), design: .rounded)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 12)
                 }
@@ -125,15 +119,13 @@ struct OnboardingFlowView: View {
 
             VStack(spacing: 18) {
                 Label("Tap the heart icon to favourite tools you love", systemImage: "heart.circle.fill")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .typography(.callout, color: primary, design: .rounded)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(primary.opacity(AppStyle.cardFillOpacity))
                     .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
                 Label("Swipe through onboarding to learn the essentials", systemImage: "hand.draw.fill")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .typography(.callout, color: primary, design: .rounded)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(primary.opacity(AppStyle.cardFillOpacity))
@@ -147,12 +139,10 @@ struct OnboardingFlowView: View {
     private var favoritesStep: some View {
         VStack(spacing: 24) {
             Text("Choose your go-to tools")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
+                .typography(.titleLarge, color: primary, design: .rounded)
 
             Text("Tap to pin tools you use the most. We'll show them right on the home screen so they’re always ready.")
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.75))
+                .typography(.callout, color: primary.opacity(0.75), design: .rounded)
                 .multilineTextAlignment(.center)
 
             ScrollView(.vertical, showsIndicators: false) {
@@ -181,12 +171,10 @@ struct OnboardingFlowView: View {
     private var workflowStep: some View {
         VStack(spacing: 26) {
             Text("Plan your first session")
-                .font(.system(size: 24, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
+                .typography(.titleLarge, color: primary, design: .rounded)
 
             Text("Tell us what you’re working on and we'll highlight the best starting point.")
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-                .foregroundStyle(primary.opacity(0.75))
+                .typography(.body, color: primary.opacity(0.75), design: .rounded)
                 .multilineTextAlignment(.center)
 
             Picker("Workflow", selection: $selectedWorkflow) {
@@ -198,20 +186,16 @@ struct OnboardingFlowView: View {
 
             VStack(alignment: .leading, spacing: 18) {
                 Label(selectedWorkflow.rawValue, systemImage: "sparkles")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .typography(.titleSmall, color: primary, design: .rounded)
                 Text(selectedWorkflow.description)
-                    .font(.system(size: 15, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.75))
+                    .typography(.callout, color: primary.opacity(0.75), design: .rounded)
 
                 Toggle(isOn: $showTips) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Show guided tips")
-                            .font(.system(size: 16, weight: .semibold, design: .rounded))
-                            .foregroundStyle(primary)
+                            .typography(.callout, color: primary, design: .rounded)
                         Text("We'll highlight useful gestures and shortcuts while you explore.")
-                            .font(.system(size: 13, weight: .medium, design: .rounded))
-                            .foregroundStyle(primary.opacity(0.6))
+                            .typography(.caption, color: primary.opacity(0.6), design: .rounded)
                     }
                 }
                 .toggleStyle(SwitchToggleStyle(tint: accent))
@@ -249,7 +233,7 @@ struct OnboardingFlowView: View {
                     currentStep -= 1
                 } label: {
                     Label("Back", systemImage: "chevron.left")
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .typography(.callout, design: .rounded)
                         .padding(.vertical, 12)
                         .padding(.horizontal, 18)
                         .background(primary.opacity(AppStyle.cardFillOpacity))
@@ -269,12 +253,11 @@ struct OnboardingFlowView: View {
                 }
             } label: {
                 Label(currentStep < 2 ? "Next" : "Let's go", systemImage: currentStep < 2 ? "chevron.right" : "checkmark.circle.fill")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .typography(.callout, color: accent, design: .rounded)
                     .padding(.vertical, 12)
                     .padding(.horizontal, 22)
                     .background(accent.opacity(colorScheme == .dark ? 0.3 : 0.18))
                     .clipShape(Capsule())
-                    .foregroundStyle(accent)
             }
             .buttonStyle(.plain)
         }
@@ -316,23 +299,19 @@ private struct FavoriteSelectionCard: View {
                                     .stroke(Color.white.opacity(0.18), lineWidth: 1)
                             )
                         Image(systemName: tool.iconName)
-                            .font(.system(size: 24, weight: .bold))
-                            .foregroundColor(.white)
+                            .typography(.titleLarge, color: .white)
                     }
 
                     Spacer()
 
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        .font(.system(size: 24, weight: .semibold))
-                        .foregroundStyle(isSelected ? accent : primary.opacity(0.35))
+                        .typography(.custom(size: 24, weight: .semibold), color: isSelected ? accent : primary.opacity(0.35))
                 }
 
                 Text(tool.title)
-                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .typography(.bodyBold, color: primary, design: .rounded)
                 Text(tool.subtitle)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundStyle(primary.opacity(0.7))
+                    .typography(.caption, color: primary.opacity(0.7), design: .rounded)
             }
             .padding(18)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -80,8 +80,7 @@ struct SettingsView: View {
     private var appearanceSection: some View {
         settingsBox {
             Text("Appearance")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.displaySmall, design: .rounded)
 
             HStack(spacing: 12) {
                 ForEach(Appearance.allCases) { mode in
@@ -103,8 +102,7 @@ struct SettingsView: View {
                             }
                         }
                         Text(mode.label)
-                            .font(.system(size: 16, weight: .regular, design: .rounded))
-                            .foregroundStyle(.primary.opacity(0.8))
+                            .typography(.callout, color: .primary.opacity(0.8), design: .rounded)
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -112,8 +110,7 @@ struct SettingsView: View {
             .padding(.top, 8)
 
             Text("Accent color")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.titleMedium, design: .rounded)
                 .padding(.top, 20)
 
             HStack(spacing: 16) {
@@ -143,8 +140,7 @@ struct SettingsView: View {
     private var otherSection: some View {
         settingsBox {
             Text("Other")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.displaySmall, design: .rounded)
 
             Toggle(isOn: $hapticsEnabled) {
                 Text("Vibration")
@@ -178,7 +174,7 @@ struct SettingsView: View {
                 HapticsManager.shared.notify(.success)
             } label: {
                 Text("Clear Cache")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .typography(.titleSmall, design: .rounded)
                     .foregroundStyle(.primary)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
@@ -193,8 +189,7 @@ struct SettingsView: View {
     private var aboutSection: some View {
         settingsBox {
             Text("About")
-                .font(.system(size: 28, weight: .bold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.displaySmall, design: .rounded)
 
             HStack {
                 Text("Version")
@@ -210,8 +205,7 @@ struct SettingsView: View {
                 }
             } label: {
                 Text("Send Feedback")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.bodyBold, design: .rounded)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
                     .background(accent.color.opacity(0.25))

--- a/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
+++ b/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
@@ -27,12 +27,10 @@ struct ToolOverview: View {
                     ToolIconView(tool: tool)
                     VStack(alignment: .leading){
                         Text(tool.title)
-                            .font(.system(size: 18, weight: .semibold, design: .rounded))
-                            .foregroundStyle(.primary)
+                            .typography(.titleMedium, color: .primary, design: .rounded)
                         
                         Text(tool.subtitle)
-                            .font(.system(size: 13, weight: .medium, design: .rounded))
-                            .foregroundStyle(.secondary)
+                            .typography(.caption, color: .secondary, design: .rounded)
                             .lineLimit(2)
                     }
                     .multilineTextAlignment(.leading)

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
@@ -51,7 +51,7 @@ struct AudioConversionView: View {
                     ConversionSuccessSheet(
                         exportURL: exportUrl,
                         accentColor: accent.color,
-                        primaryColor: primary,
+                        primaryColor: .primary,
                         onSave: { activeSheet = .exporter(exportUrl) },
                         onDone: { activeSheet = nil }
                     )
@@ -60,7 +60,7 @@ struct AudioConversionView: View {
                 case .fail:
                     ConversionFailSheet(
                         accentColor: accent.color,
-                        primaryColor: primary,
+                        primaryColor: .primary,
                         onRetry: { },
                         onDone: { activeSheet = nil }
                     )
@@ -127,7 +127,7 @@ struct AudioConversionView: View {
         HStack {
             Text("Extract audio")
                 .font(.system(size: 32, weight: .bold, design: .rounded))
-                .foregroundStyle(primary)
+                .foregroundStyle(.primary)
 
             Spacer()
 
@@ -140,11 +140,11 @@ struct AudioConversionView: View {
                     .foregroundColor(colorScheme == .dark ? .white : .black)
                     .padding(.vertical, 10)
                     .padding(.horizontal, 20)
-                    .background(primary.opacity(0.07))
+                    .background(.primary.opacity(0.07))
                     .clipShape(Capsule())
                     .overlay(
                         Capsule()
-                            .stroke(primary.opacity(0.15), lineWidth: 1)
+                            .stroke(.primary.opacity(0.15), lineWidth: 1)
                     )
                     .shadow(ShadowConfiguration.smallConfiguration(for: colorScheme))
             }
@@ -197,14 +197,14 @@ struct AudioConversionView: View {
         settingsCard {
             Text("File Size")
                 .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
+                .foregroundStyle(.primary)
 
             HStack(spacing: 16) {
                 Text("Original: \(viewModel.getVideoFileSize())")
                 Text("Estimated: \(viewModel.getEstimateExportFileSize())")
             }
             .font(.system(size: 14))
-            .foregroundStyle(primary.opacity(0.8))
+            .foregroundStyle(.primary.opacity(0.8))
         }
     }
 
@@ -212,16 +212,16 @@ struct AudioConversionView: View {
         settingsCard {
             Text("Format")
                 .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
+                .foregroundStyle(.primary)
 
             Text("Original: \(originalFormatLabel)")
                 .font(.system(size: 14))
-                .foregroundStyle(primary.opacity(0.8))
+                .foregroundStyle(.primary.opacity(0.8))
 
             HStack {
                 Text("When Exported:")
                     .font(.system(size: 14))
-                    .foregroundStyle(primary.opacity(0.8))
+                    .foregroundStyle(.primary.opacity(0.8))
 
                 Picker("", selection: $viewModel.selectedFormat) {
                     Text("mp3").tag(AudioFormat.mp3)
@@ -238,11 +238,11 @@ struct AudioConversionView: View {
             HStack {
                 Text("Bitrate")
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(primary)
+                    .foregroundStyle(.primary)
                 Spacer()
                 Text(bitrateLabel)
                     .font(.system(size: 14))
-                    .foregroundStyle(primary.opacity(0.8))
+                    .foregroundStyle(.primary.opacity(0.8))
                 Button(action: { withAnimation { showBitrateInfo.toggle() } }) {
                     Image(systemName: "info.circle")
                         .opacity(0.5)
@@ -253,14 +253,14 @@ struct AudioConversionView: View {
             if showBitrateInfo {
                 Text("Bitrate controls audio quality and file size.")
                     .font(.system(size: 13))
-                    .foregroundStyle(primary.opacity(0.7))
+                    .foregroundStyle(.primary.opacity(0.7))
                     .transition(.opacity)
             }
 
             if viewModel.selectedFormat == .wav {
-                Text("WAV exports keep the original quality (~\(viewModel.getWavBitrateKbps) kbps).")
+                Text("WAV exports keep the original quality (~\(String(describing: viewModel.getWavBitrateKbps)) kbps).")
                     .font(.system(size: 13))
-                    .foregroundStyle(primary.opacity(0.7))
+                    .foregroundStyle(.primary.opacity(0.7))
                     .transition(.opacity)
             } else {
                 Slider(value: $viewModel.bitrate, in: 64...320, step: 1)
@@ -332,11 +332,11 @@ struct AudioConversionView: View {
             VideoPreviewCard(
                 url: viewModel.videoURL,
                 size: size,
-                primaryColor: primary
+                primaryColor: .primary
             )
             Text("Video")
                 .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
+                .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(maxWidth: .infinity)
@@ -346,13 +346,13 @@ struct AudioConversionView: View {
         VStack(spacing: 12) {
             AudioPreviewCard(
                 size: size,
-                primaryColor: primary,
+                primaryColor: .primary,
                 accentColor: accent.color,
                 audioURL: .constant(nil)
             )
             Text("Audio")
                 .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary)
+                .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(maxWidth: .infinity)
@@ -363,7 +363,7 @@ struct AudioConversionView: View {
             Spacer(minLength: 0)
             Image(systemName: "arrow.right")
                 .font(.system(size: 24, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary.opacity(0.55))
+                .foregroundStyle(.primary.opacity(0.55))
             Spacer(minLength: 0)
         }
         .frame(width: width, height: height)
@@ -398,7 +398,7 @@ struct AudioConversionView: View {
                 .tint(accent.color)
             Text("\(Int(clampedProgress * 100))% complete")
                 .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundStyle(primary.opacity(0.7))
+                .foregroundStyle(.primary.opacity(0.7))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
@@ -126,8 +126,7 @@ struct AudioConversionView: View {
     private var headerRow: some View {
         HStack {
             Text("Extract audio")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.displayMedium, design: .rounded)
 
             Spacer()
 
@@ -136,8 +135,11 @@ struct AudioConversionView: View {
                 dismiss()
             }) {
                 Text("Done")
-                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                    .typography(
+                        .titleSmall,
+                        color: colorScheme == .dark ? .white : .black,
+                        design: .rounded
+                    )
                     .padding(.vertical, 10)
                     .padding(.horizontal, 20)
                     .background(.primary.opacity(0.07))
@@ -196,32 +198,27 @@ struct AudioConversionView: View {
     private var fileSizePanel: some View {
         settingsCard {
             Text("File Size")
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.titleSmall, design: .rounded)
 
             HStack(spacing: 16) {
                 Text("Original: \(viewModel.getVideoFileSize())")
                 Text("Estimated: \(viewModel.getEstimateExportFileSize())")
             }
-            .font(.system(size: 14))
-            .foregroundStyle(.primary.opacity(0.8))
+            .typography(.caption, color: .primary.opacity(0.8))
         }
     }
 
     private var formatPanel: some View {
         settingsCard {
             Text("Format")
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.bodyBold, design: .rounded)
 
             Text("Original: \(originalFormatLabel)")
-                .font(.system(size: 14))
-                .foregroundStyle(.primary.opacity(0.8))
+                .typography(.caption, color: .primary.opacity(0.8))
 
             HStack {
                 Text("When Exported:")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.primary.opacity(0.8))
+                    .typography(.caption, color: .primary.opacity(0.8))
 
                 Picker("", selection: $viewModel.selectedFormat) {
                     Text("mp3").tag(AudioFormat.mp3)
@@ -237,12 +234,10 @@ struct AudioConversionView: View {
         settingsCard {
             HStack {
                 Text("Bitrate")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.bodyBold, design: .rounded)
                 Spacer()
                 Text(bitrateLabel)
-                    .font(.system(size: 14))
-                    .foregroundStyle(.primary.opacity(0.8))
+                    .typography(.caption, color: .primary.opacity(0.8))
                 Button(action: { withAnimation { showBitrateInfo.toggle() } }) {
                     Image(systemName: "info.circle")
                         .opacity(0.5)
@@ -252,15 +247,13 @@ struct AudioConversionView: View {
 
             if showBitrateInfo {
                 Text("Bitrate controls audio quality and file size.")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.primary.opacity(0.7))
+                    .typography(.caption, color: .primary.opacity(0.7))
                     .transition(.opacity)
             }
 
             if viewModel.selectedFormat == .wav {
                 Text("WAV exports keep the original quality (~\(String(describing: viewModel.getWavBitrateKbps)) kbps).")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.primary.opacity(0.7))
+                    .typography(.caption, color: .primary.opacity(0.7))
                     .transition(.opacity)
             } else {
                 Slider(value: $viewModel.bitrate, in: 64...320, step: 1)
@@ -272,7 +265,7 @@ struct AudioConversionView: View {
     private var advancedToggleButton: some View {
         Button(action: toggleAdvanced) {
             Text(showAdvanced ? "Hide" : "More")
-                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                .typography(.bodyBold, design: .rounded)
                 .frame(maxWidth: .infinity)
         }
         .foregroundStyle(accent.color)
@@ -335,8 +328,7 @@ struct AudioConversionView: View {
                 primaryColor: .primary
             )
             Text("Video")
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.titleMedium, design: .rounded)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(maxWidth: .infinity)
@@ -351,8 +343,7 @@ struct AudioConversionView: View {
                 audioURL: .constant(nil)
             )
             Text("Audio")
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.titleMedium, design: .rounded)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(maxWidth: .infinity)
@@ -362,8 +353,7 @@ struct AudioConversionView: View {
         VStack {
             Spacer(minLength: 0)
             Image(systemName: "arrow.right")
-                .font(.system(size: 24, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary.opacity(0.55))
+                .typography(.custom(size: 24, weight: .semibold), color: .primary.opacity(0.55), design: .rounded)
             Spacer(minLength: 0)
         }
         .frame(width: width, height: height)
@@ -374,8 +364,7 @@ struct AudioConversionView: View {
             HStack {
                 Spacer()
                 Text(isProcessing ? "Converting…" : "Convert")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundColor(background)
+                    .typography(.titleMedium, color: background, design: .rounded)
                 Spacer()
             }
             .padding(.vertical, 14)
@@ -397,8 +386,7 @@ struct AudioConversionView: View {
             ProgressView(value: clampedProgress, total: 1)
                 .tint(accent.color)
             Text("\(Int(clampedProgress * 100))% complete")
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary.opacity(0.7))
+                .typography(.captionBold, color: .primary.opacity(0.7))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -500,9 +488,8 @@ private struct VideoPreviewCard: View {
         .overlay(alignment: .bottomLeading) {
             if duration > 0 {
                 Text(formatTime(isPlaying ? currentTime : duration))
-                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .typography(.custom(size: 15, weight: .bold), color: .white, design: .rounded)
                     .padding(11)
-                    .foregroundColor(.white)
                     .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
             }
         }
@@ -681,8 +668,7 @@ private struct AudioPreviewCard: View {
 
             // Icon layer
             Image(systemName: "waveform")
-                .font(.system(size: iconSize, weight: .regular))
-                .foregroundStyle(accentColor.opacity(1))
+                .typography(.custom(size: iconSize, weight: .regular), color: accentColor.opacity(1))
         }
         .frame(width: size, height: size)
         .clipShape(baseShape)
@@ -694,9 +680,7 @@ private struct AudioPreviewCard: View {
         .overlay(alignment: .bottomLeading) {
             if duration > 0 {
                 Text(formatTime(isPlaying ? currentTime : duration))
-                    .font(.system(size: 15, weight: .bold, design: .rounded))
-                    .padding(8)
-                    .foregroundColor(.white)
+                    .typography(.custom(size: 15, weight: .bold), color: .white, design: .rounded)
                     .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
             }
         }
@@ -819,10 +803,9 @@ private struct PlaybackControlIcon: View {
     let iconColor: Color
 
     var body: some View {
-            Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundColor(iconColor)
-                    .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
+        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+            .typography(.custom(size: 32, weight: .bold), color: iconColor)
+            .shadow(color: .black.opacity(0.85), radius: 6, x: 0, y: 2)
     }
 }
 

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/Sheets/ConversionFailSheet.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/Sheets/ConversionFailSheet.swift
@@ -37,8 +37,7 @@ struct ConversionFailSheet: View {
     private var header: some View {
         HStack {
             Text("Conversion Failed")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .foregroundStyle(primaryColor)
+                .typography(.displayMedium, color: primaryColor)
 
             Spacer()
 
@@ -47,8 +46,7 @@ struct ConversionFailSheet: View {
                 onDone()
             }) {
                 Text("Dismiss")
-                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                    .typography(.titleSmall, color: colorScheme == .dark ? .white: .black)
                     .padding(.vertical, 10)
                     .padding(.horizontal, 20)
                     .background(primaryColor.opacity(0.07))
@@ -76,8 +74,7 @@ struct ConversionFailSheet: View {
 
                 Image(systemName: showXmark ? "xmark.circle.fill" : "circle.fill")
                     .contentTransition(.symbolEffect(.replace))
-                    .font(.system(size: 96, weight: .bold, design: .rounded))
-                    .foregroundStyle(Color.red)
+                    .typography(.custom(size: 96, weight: .bold), color: .red, design: .rounded)
                     .scaleEffect(animateError ? 1 : 0.65)
                     .shadow(color: Color.red.opacity(0.35), radius: 18, x: 0, y: 12)
             }
@@ -86,13 +83,11 @@ struct ConversionFailSheet: View {
             .onAppear(perform: startAnimation)
 
             Text("Something went wrong while saving.")
-                .font(.system(size: 25, weight: .semibold, design: .rounded))
-                .foregroundStyle(primaryColor)
+                .typography(.titleLarge, color: primaryColor)
                 .multilineTextAlignment(.center)
 
             Text("Please try again or check your storage permissions.")
-                .font(.system(size: 17, weight: .regular, design: .rounded))
-                .foregroundStyle(.secondary)
+                .typography(.titleSmall, color: .secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
         }
@@ -147,8 +142,7 @@ struct ConversionFailSheet: View {
         HStack {
             Spacer()
             Label(title, systemImage: systemImage)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundColor(foreground)
+                .typography(.titleSmall, color: foreground, design: .rounded)
             Spacer()
         }
         .padding(.vertical, 14)

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/Sheets/ConversionSuccessSheet.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/Sheets/ConversionSuccessSheet.swift
@@ -37,8 +37,7 @@ struct ConversionSuccessSheet: View {
     private var header: some View {
         HStack {
             Text("Converted!")
-                .font(.system(size: 32, weight: .bold, design: .rounded))
-                .foregroundStyle(primaryColor)
+                .typography(.displayMedium, color: primaryColor, design: .rounded)
 
             Spacer()
 
@@ -47,8 +46,11 @@ struct ConversionSuccessSheet: View {
                 onDone()
             }) {
                 Text("Done")
-                    .font(.system(size: 17, weight: .semibold, design: .rounded))
-                    .foregroundColor(colorScheme == .dark ? .white : .black)
+                    .typography(
+                        .titleSmall,
+                        color: colorScheme == .dark ? .white : .black,
+                        design: .rounded
+                    )
                     .padding(.vertical, 10)
                     .padding(.horizontal, 20)
                     .background(primaryColor.opacity(0.07))
@@ -75,8 +77,7 @@ struct ConversionSuccessSheet: View {
 
                 Image(systemName: showCheckmark ? "checkmark.circle.fill" : "circle.fill")
                     .contentTransition(.symbolEffect(.replace))
-                    .font(.system(size: 96, weight: .bold, design: .rounded))
-                    .foregroundStyle(Color.green)
+                    .typography(.custom(size: 96, weight: .bold), color: .green, design: .rounded)
                     .scaleEffect(animateCheck ? 1 : 0.65)
                     .shadow(color: Color.green.opacity(0.35), radius: 18, x: 0, y: 12)
             }
@@ -85,8 +86,7 @@ struct ConversionSuccessSheet: View {
             .onAppear(perform: startAnimation)
 
             Text("Successfully converted.")
-                .font(.system(size: 25, weight: .semibold, design: .rounded))
-                .foregroundStyle(primaryColor)
+                .typography(.titleMedium, color: primaryColor, design: .rounded)
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, AppStyle.horizontalPadding)
@@ -137,8 +137,7 @@ struct ConversionSuccessSheet: View {
         HStack {
             Spacer()
             Label(title, systemImage: systemImage)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .foregroundColor(foreground)
+                .typography(.titleSmall, color: foreground, design: .rounded)
             Spacer()
         }
         .padding(.vertical, 14)

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorView.swift
@@ -74,26 +74,22 @@ struct AudioExtractorView: View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Extractor")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary.opacity(0.7))
+                    .typography(.titleMedium, color: .primary.opacity(0.7), design: .rounded)
                 Text("Pull crisp audio from your videos")
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.displaySmall, design: .rounded)
             }
 
             Spacer()
 
             Image(systemName: "waveform")
-                .font(.system(size: 30, weight: .bold))
-                .foregroundStyle(accent.color)
+                .typography(.custom(size: 30, weight: .bold), color: accent.color)
         }
     }
 
     private var sourceOptionsSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Choose a source")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(.primary)
+                .typography(.titleMedium, design: .rounded)
 
             HStack(spacing: 16) {
                 sourceOptionCard(icon: "doc.fill", title: "Import from Files") {
@@ -115,11 +111,9 @@ struct AudioExtractorView: View {
             AppCard {
                 VStack(spacing: 12) {
                     Image(systemName: icon)
-                        .font(.system(size: 30, weight: .semibold))
-                        .foregroundStyle(.primary)
+                        .typography(.custom(size: 30, weight: .semibold))
                     Text(title)
-                        .font(.system(size: 16, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.primary)
+                        .typography(.titleSmall, design: .rounded)
                         .multilineTextAlignment(.center)
                 }
                 .frame(maxWidth: .infinity)
@@ -133,16 +127,14 @@ struct AudioExtractorView: View {
         AppCard{
             VStack(alignment: .leading, spacing: 12) {
                 Text("Recent conversions")
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.titleLarge, design: .rounded)
                     .padding(.top, 16)
                     .padding(.horizontal, 12)
                 
                 VStack(spacing: 12) {
                     if viewModel.recents.isEmpty {
                         Text("No exports yet")
-                            .font(.system(size: 17, weight: .medium, design: .rounded))
-                            .foregroundStyle(.primary.opacity(0.7))
+                            .typography(.titleSmall, color: .primary.opacity(0.7), design: .rounded)
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.vertical, 40)
                     } else {
@@ -170,8 +162,7 @@ struct AudioExtractorView: View {
                                 }
                             } label: {
                                 Text(showAllRecents ? "Show less" : "Show more")
-                                    .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                    .foregroundStyle(.primary.opacity(0.75))
+                                    .typography(.bodyBold, color: .primary.opacity(0.75), design: .rounded)
                             }
                             .padding(.top, 6)
                         }

--- a/Resonans/Views/Tools/ToolItems/DummyToolView.swift
+++ b/Resonans/Views/Tools/ToolItems/DummyToolView.swift
@@ -28,18 +28,15 @@ struct DummyToolView: View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Dummy Playground")
-                    .font(.system(size: 18, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary.opacity(0.7))
+                    .typography(.titleMedium, color: .primary.opacity(0.7), design: .rounded)
                 Text("Experiment with tool navigation")
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
+                    .typography(.displaySmall, design: .rounded)
             }
 
             Spacer()
 
             Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: 30, weight: .bold))
-                .foregroundStyle(accent.color)
+                .typography(.custom(size: 30, weight: .bold), color: accent.color)
         }
     }
 
@@ -47,12 +44,10 @@ struct DummyToolView: View {
         AppCard{
             VStack(alignment: .leading, spacing: 16) {
                 Text("This is a simple placeholder tool designed to help you test how the multi-tool flow behaves when several entries are available.")
-                    .font(.system(size: 17, weight: .medium, design: .rounded))
-                    .foregroundStyle(.primary.opacity(0.8))
+                    .typography(.titleSmall, color: .primary.opacity(0.8), design: .rounded)
                 
                 Text("Close the tool from the header or the list to return to the tool overview. Everything here is purely for demonstration purposes.")
-                    .font(.system(size: 16, weight: .regular, design: .rounded))
-                    .foregroundStyle(.primary.opacity(0.7))
+                    .typography(.callout, color: .primary.opacity(0.7), design: .rounded)
             }
             .padding(.horizontal, AppStyle.innerPadding)
             .padding(.vertical, 24)


### PR DESCRIPTION
This PR introduces a centralized typography system that defines a single source of truth for all text styles used in the app. The goal is to maintain visual consistency, simplify font updates, and ensure alignment with the design system.

**💡 Motivation**
Previously, font styles (e.g., `.font(.system(size: 17, weight: .medium))`) were applied manually across different views. This approach made it:
- Harder to maintain visual consistency
- Tedious to adjust global typography changes
- Prone to human error and design drift

By introducing a centralized Typography enum and typography(_:) view modifier, we can now:
- Apply consistent font sizes and weights across all screens
- Update the design system in one place(e.g, apply new font or size)
- Improve readability and reduce repetitive font declarations

A new file, `Typography.swift` was added under Utilities.
It defines:
- enum `Typography`: encapsulates all reusable text styles (e.g., .displayLarge, .titleMedium, .body, .caption)
- `typography(_ style: Typography, color: Color? = nil)`: a SwiftUI ViewModifier that applies the corresponding font and optional colors
- a custom case `.custom(size: CGFloat, weight: Font.Weight)` if you need further sizing.

Implementation Example 
```
Text("Welcome Back")
    .typography(.titleLarge, design: .rounded)

Text("Tap to continue")
    .typography(.caption, color: .secondary)

Text("Special Label")
    .typography(.custom(size: 15, weight: .semibold))

```