### PR TITLE
Refine tab visuals and repair audio extractor UX

### DIFF
--- a/Resonans/Assets.xcassets/icon.imageset/Contents.json
+++ b/Resonans/Assets.xcassets/icon.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "icon.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Resonans/Assets.xcassets/icon.imageset/icon.svg
+++ b/Resonans/Assets.xcassets/icon.imageset/icon.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18 12H32C40.8366 12 48 19.1634 48 28C48 36.8366 40.8366 44 32 44H26L38 56H26L12 42V12H18Z" fill="currentColor"/>
+</svg>

--- a/Resonans/Views/AppCard.swift
+++ b/Resonans/Views/AppCard.swift
@@ -72,23 +72,25 @@ struct AppCard<Content: View>: View {
     private var glassView: some View {
         content()
             .padding()
-            .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 30))
+            .glassEffect(.regular.interactive(), in: .rect(cornerRadius: AppStyle.cornerRadius))
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(5)
     }
-    
+
     private var nonGlassView: some View {
         content()
             .padding()
             .background(
-                RoundedRectangle(cornerRadius: 30, style: .continuous)
+                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                     .fill(.primary.opacity(0.09))
                     .overlay(
-                        RoundedRectangle(cornerRadius: 30, style: .continuous)
+                        RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                             .strokeBorder(.primary.opacity(0.10), lineWidth: 1)
                     )
             )
-            .contentShape(RoundedRectangle(cornerRadius: 30, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))
             .shadow(ShadowConfiguration.smallConfiguration(for: colorScheme))
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(5)
     }
 }

--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -18,7 +18,16 @@ struct ContentView: View {
                 HomeDashboardView(accent: accent, primary: .primary)
                     .environmentObject(viewModel)
             }, label: {
-                Label("Home", systemImage: "house")
+                Label {
+                    Text("Home")
+                } icon: {
+                    Image("icon")
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 24, height: 24)
+                        .accessibilityHidden(true)
+                }
             })
             Tab(value: .tools, content: {
                 NavigationStack{

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -47,12 +47,16 @@ struct HomeDashboardView: View {
                                 .foregroundStyle(accent.color)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 16)
-                                .background(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.18))
-                                .clipShape(RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous))
+                                .padding(.horizontal, 18)
+                                .background(
+                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                                        .fill(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.2))
+                                )
                                 .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
                                         .stroke(accent.color.opacity(0.35), lineWidth: 1)
                                 )
+                                .shadow(color: accent.color.opacity(colorScheme == .dark ? 0.25 : 0.2), radius: 16, x: 0, y: 10)
                             }
                             .buttonStyle(.plain)
                         }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -206,10 +206,16 @@ struct SettingsView: View {
             } label: {
                 Text("Send Feedback")
                     .typography(.bodyBold, design: .rounded)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(accent.color.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                            .fill(accent.color.opacity(0.22))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                            .stroke(accent.color.opacity(0.35), lineWidth: 1)
+                    )
                     .shadow(ShadowConfiguration.smallConfiguration(for: colorScheme))
             }
             .padding(.top, 12)

--- a/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
+++ b/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
@@ -36,6 +36,7 @@ struct ToolOverview: View {
                     .multilineTextAlignment(.leading)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationDestination(isPresented: Binding(get: {
             if isHomeboard{

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
@@ -142,10 +142,12 @@ struct AudioConversionView: View {
                     )
                     .padding(.vertical, 10)
                     .padding(.horizontal, 20)
-                    .background(.primary.opacity(0.07))
-                    .clipShape(Capsule())
+                    .background(
+                        RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
+                            .fill(.primary.opacity(0.07))
+                    )
                     .overlay(
-                        Capsule()
+                        RoundedRectangle(cornerRadius: AppStyle.compactCornerRadius, style: .continuous)
                             .stroke(.primary.opacity(0.15), lineWidth: 1)
                     )
                     .shadow(ShadowConfiguration.smallConfiguration(for: colorScheme))
@@ -367,10 +369,16 @@ struct AudioConversionView: View {
                     .typography(.titleMedium, color: background, design: .rounded)
                 Spacer()
             }
-            .padding(.vertical, 14)
-            .background(accent.color.opacity(isProcessing ? 0.6 : 1))
-            .clipShape(Capsule())
-            .shadow(color: accent.color.opacity(0.35), radius: 14, x: 0, y: 8)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                    .fill(accent.color.opacity(isProcessing ? 0.65 : 1))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
+                    .stroke(accent.color.opacity(0.35), lineWidth: 1)
+            )
+            .shadow(color: accent.color.opacity(0.3), radius: 16, x: 0, y: 10)
         }
         .disabled(isProcessing)
         .opacity(isProcessing ? 0.9 : 1)

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionViewModel.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionViewModel.swift
@@ -13,8 +13,8 @@ final class AudioConversionViewModel: ObservableObject {
     @Published var selectedFormat: AudioFormat = .mp3
     @Published var bitrate: Double = 192
     @Published var audioDuration: Double = 0
-    @Published var audioSampleRate: Double = 44_100
-    @Published var audioChannelCount: Int = 2
+    @Published var audioSampleRate: Double = 0
+    @Published var audioChannelCount: Int = 0
     @Published var audioStatus: AudioStatus = .initiate
     var videoURL: URL = URL(fileURLWithPath: "")
     var exportUrl: String?
@@ -25,7 +25,7 @@ final class AudioConversionViewModel: ObservableObject {
     }
     
     var isLoadedAudioMetadata: Bool {
-        audioDuration > 0 || audioSampleRate > 0 || audioChannelCount > 0
+        audioDuration > 0
     }
     
     func getVideoFileSize() -> String {
@@ -94,6 +94,7 @@ final class AudioConversionViewModel: ObservableObject {
     
     func convertToAudio() {
         let targetBitrate = Int(max(min(bitrate, 320), 64))
+        audioStatus = .inprogress(0)
         videoConverter.convert(
             videoURL: videoURL,
             format: selectedFormat,

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorViewModel.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 final class AudioExtractorViewModel: ObservableObject {
-    var recents: [RecentItem] = []
+    @Published var recents: [RecentItem] = []
     let cacheManager: CacheManager
     
     init(cacheManager: CacheManager) {

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -10,11 +10,15 @@ struct ToolsView: View {
     @Namespace private var namespace
     
     var body: some View {
-        ScrollView{
-            ForEach(ToolItem.all) { tool in
-                ToolOverview(tool: tool)
-                    .environmentObject(viewModel)
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: 20) {
+                ForEach(ToolItem.all) { tool in
+                    ToolOverview(tool: tool)
+                        .environmentObject(viewModel)
+                }
             }
+            .padding(.horizontal, AppStyle.horizontalPadding)
+            .padding(.vertical, AppStyle.innerPadding)
         }
         .background(
             LinearGradient(
@@ -26,6 +30,9 @@ struct ToolsView: View {
             .scaledToFill()
         )
         .navigationTitle("Tools")
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarColorScheme(.automatic, for: .navigationBar)
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the Home tab SF Symbol with the branded asset icon and keep the tab visuals consistent with the rest of the bar
- align glass cards and tool listings with shared padding/blur so containers share the same "liquid" treatment across the app
- refresh extractor controls, publish recents, and load metadata so estimated file sizes and exports behave again

## Testing
- not run (requires Xcode/macOS environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2c0d1b37c83208ef319e4e4202369