### PR TITLE
Refine app styling and image orientation handling

### DIFF
--- a/Resonans/Utilities/CGImagePropertyOrientation+Extensions.swift
+++ b/Resonans/Utilities/CGImagePropertyOrientation+Extensions.swift
@@ -1,0 +1,19 @@
+import ImageIO
+import UIKit
+
+extension CGImagePropertyOrientation {
+    init(_ orientation: UIImage.Orientation) {
+        switch orientation {
+        case .up: self = .up
+        case .down: self = .down
+        case .left: self = .left
+        case .right: self = .right
+        case .upMirrored: self = .upMirrored
+        case .downMirrored: self = .downMirrored
+        case .leftMirrored: self = .leftMirrored
+        case .rightMirrored: self = .rightMirrored
+        @unknown default:
+            self = .up
+        }
+    }
+}

--- a/Resonans/Views/AppBackgroundView.swift
+++ b/Resonans/Views/AppBackgroundView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct AppBackgroundView: View {
+    let accent: AccentColorOption
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var gradient: LinearGradient {
+        let baseColor = accent.color
+        let topOpacity = colorScheme == .dark ? 0.55 : 0.35
+        let midOpacity = colorScheme == .dark ? 0.25 : 0.15
+        return LinearGradient(
+            colors: [
+                baseColor.opacity(topOpacity),
+                baseColor.opacity(midOpacity),
+                AppStyle.background(for: colorScheme)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    var body: some View {
+        AppStyle.background(for: colorScheme)
+            .overlay(gradient)
+            .overlay(noiseOverlay.opacity(colorScheme == .dark ? 0.08 : 0.04))
+            .ignoresSafeArea()
+    }
+
+    private var noiseOverlay: some View {
+        RadialGradient(
+            gradient: Gradient(colors: [
+                Color.white.opacity(colorScheme == .dark ? 0.04 : 0.08),
+                .clear
+            ]),
+            center: .top,
+            startRadius: 0,
+            endRadius: 600
+        )
+    }
+}
+
+extension View {
+    func appBackground(accent: AccentColorOption) -> some View {
+        background(AppBackgroundView(accent: accent))
+    }
+}

--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -7,9 +7,6 @@ struct ContentView: View {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("showGuidedTips") private var showGuidedTips = true
 
-    @Environment(\.colorScheme) private var colorScheme
-    
-    private var background: Color { AppStyle.background(for: colorScheme) }
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
 
     var body: some View {
@@ -58,6 +55,7 @@ struct ContentView: View {
                 HapticsManager.shared.notify(.success)
             }
         }
+        .background(AppBackgroundView(accent: accent))
         .tint(accent.color)
     }
 }

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -107,14 +107,7 @@ struct HomeDashboardView: View {
                     Spacer(minLength: 60)
                 }
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
+            .appBackground(accent: accent)
             .navigationTitle("Home")
         }
     }

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -52,14 +52,7 @@ struct SettingsView: View {
                 }
                 .padding(.bottom, AppStyle.innerPadding)
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
+            .appBackground(accent: accent)
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(content: {

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionView.swift
@@ -115,12 +115,7 @@ struct AudioConversionView: View {
     }
 
     private var backgroundGradient: some View {
-        LinearGradient(
-            colors: [accent.gradient, colorScheme == .dark ? .black : .white],
-            startPoint: .topLeading,
-            endPoint: .bottom
-        )
-        .ignoresSafeArea()
+        AppBackgroundView(accent: accent)
     }
 
     private var headerRow: some View {

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorView.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioExtractorView.swift
@@ -6,7 +6,6 @@ struct AudioExtractorView: View {
     @State private var showAllRecents = false
     @State private var activeSheet: ActiveSheet?
 
-    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
 
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
@@ -64,14 +63,7 @@ struct AudioExtractorView: View {
                 viewModel.recents = items
             }
         }
-        .background(
-            LinearGradient(
-                colors: [accent.gradient, .clear],
-                startPoint: .topLeading,
-                endPoint: .bottom
-            )
-            .ignoresSafeArea()
-        )
+        .appBackground(accent: accent)
     }
 
     private var headerSection: some View {

--- a/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
@@ -12,18 +12,19 @@ import SwiftUI
 import Vision
 
 final class BgRemoverTool {
-    func removeBackground(from image: UIImage) async throws -> UIImage? {
+    func removeBackground(from image: UIImage) async throws -> UIImage {
         guard let inputImage = CIImage(image: image) else {
             throw BgRemoverError.convertError
         }
-        let maskImage = try createMask(from: inputImage)
+        let orientation = CGImagePropertyOrientation(image.imageOrientation)
+        let maskImage = try createMask(from: inputImage, orientation: orientation)
         let outputImage = applyMask(mask: maskImage, to: inputImage)
-        return try convertToUIImage(ciImage: outputImage)
+        return try convertToUIImage(ciImage: outputImage, originalImage: image)
     }
-    
-    private func createMask(from inputImage: CIImage) throws -> CIImage {
+
+    private func createMask(from inputImage: CIImage, orientation: CGImagePropertyOrientation) throws -> CIImage {
         let request = VNGenerateForegroundInstanceMaskRequest()
-        let handler = VNImageRequestHandler(ciImage: inputImage)
+        let handler = VNImageRequestHandler(ciImage: inputImage, orientation: orientation)
         
         do {
             try handler.perform([request])
@@ -44,20 +45,20 @@ final class BgRemoverTool {
     
     private func applyMask(mask: CIImage, to image: CIImage) -> CIImage {
         let filter = CIFilter.blendWithMask()
-        
+
         filter.inputImage = image
         filter.maskImage = mask
         filter.backgroundImage = CIImage.empty()
-        
-        return filter.outputImage ?? image
+
+        return (filter.outputImage ?? image).cropped(to: image.extent)
     }
-    
-    private func convertToUIImage(ciImage: CIImage) throws -> UIImage {
+
+    private func convertToUIImage(ciImage: CIImage, originalImage: UIImage) throws -> UIImage {
         guard let cgImage = CIContext(options: nil).createCGImage(ciImage, from: ciImage.extent) else {
             throw BgRemoverError.convertError
         }
-        
-        return UIImage(cgImage: cgImage)
+
+        return UIImage(cgImage: cgImage, scale: originalImage.scale, orientation: originalImage.imageOrientation)
     }
 }
 

--- a/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverView.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverView.swift
@@ -54,16 +54,9 @@ struct BgRemoverView: View {
                         AllowCameraSheet(status: status)
                     }
                 }
-                .background(
-                    LinearGradient(
-                        colors: [accent.gradient, .clear],
-                        startPoint: .topLeading,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
-                )
             }
         }
+        .appBackground(accent: accent)
     }
     
     private var headerSection: some View {

--- a/Resonans/Views/Tools/ToolItems/BgRemover/RemoveBackground/RemoveBackgroundView.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/RemoveBackground/RemoveBackgroundView.swift
@@ -11,7 +11,6 @@ struct RemoveBackgroundView: View {
     @StateObject var viewModel: RemoveBackgroundViewModel
     
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
     @State var activeSheet: ActiveSheet?
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
@@ -30,14 +29,7 @@ struct RemoveBackgroundView: View {
         .presentationDetents([.medium])
         .padding(.top, 12)
         .padding(.horizontal, 24)
-        .background(
-            LinearGradient(
-                colors: [accent.gradient, colorScheme == .dark ? .black : .white],
-                startPoint: .topLeading,
-                endPoint: .bottom
-            )
-            .ignoresSafeArea()
-        )
+        .appBackground(accent: accent)
         .onChange(of: viewModel.errorMessage) { oldError, newError in
             if let newError, oldError != newError, !newError.isEmpty {
                 activeSheet = .removeFailed(errorMessage: newError)

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 struct ToolsView: View {
     let accent: AccentColorOption
     let primary: Color
-    @Environment(\.colorScheme) private var colorScheme
-    
     @EnvironmentObject private var viewModel: ContentViewModel
     
     @Namespace private var namespace
@@ -30,15 +28,7 @@ struct ToolsView: View {
                 .padding(.horizontal, AppStyle.horizontalPadding)
                 .padding(.vertical, AppStyle.innerPadding)
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-                .scaledToFill()
-            )
+            .appBackground(accent: accent)
             .navigationTitle("Tools")
         }
     }


### PR DESCRIPTION
## Summary
- add a reusable AppBackgroundView to provide a consistent gradient background across primary screens and tools
- apply the new background styling to home, tools, settings, and tool detail flows for a unified look
- fix background remover conversions by honoring the original image orientation during mask generation and rendering

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6903f0800dd08320ab83a1b8c4a5effd