### PR TITLE
Refine layout styling and fix background remover output

### DIFF
--- a/Resonans/Components/AppBackground.swift
+++ b/Resonans/Components/AppBackground.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// A reusable background view that provides a consistent app-wide appearance
+/// by blending the selected accent color with the system background.
+///
+/// The gradient adapts to the active color scheme to keep contrast balanced
+/// in both light and dark modes.
+struct AppBackground: View {
+    let accent: AccentColorOption
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        LinearGradient(
+            colors: gradientColors,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+    }
+
+    private var gradientColors: [Color] {
+        let base = AppStyle.background(for: colorScheme)
+        let accentColor = accent.color
+
+        if colorScheme == .dark {
+            return [
+                accentColor.opacity(0.45),
+                accentColor.opacity(0.15),
+                base
+            ]
+        } else {
+            return [
+                accentColor.opacity(0.28),
+                accentColor.opacity(0.1),
+                base
+            ]
+        }
+    }
+}
+
+extension View {
+    /// Applies the standard Resonans background behind the current view hierarchy.
+    func appBackground(accent: AccentColorOption) -> some View {
+        background(AppBackground(accent: accent))
+    }
+}

--- a/Resonans/Views/AppCard.swift
+++ b/Resonans/Views/AppCard.swift
@@ -89,10 +89,10 @@ struct AppCard<Content: View>: View {
             .frame(maxWidth: isMaxWidth ? .infinity : nil, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                    .fill(.primary.opacity(0.09))
+                    .fill(Color.primary.opacity(AppStyle.cardFillOpacity))
                     .overlay(
                         RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                            .strokeBorder(.primary.opacity(0.10), lineWidth: 1)
+                            .strokeBorder(Color.primary.opacity(AppStyle.strokeOpacity), lineWidth: 1)
                     )
             )
             .contentShape(RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous))

--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -35,13 +35,13 @@ struct ContentView: View {
             }, label: {
                 Label("Tools", systemImage: "wrench.and.screwdriver.fill")
             })
-            Tab(value: .settings){
+            Tab(value: .settings) {
                 SettingsView()
-            }label: {
+            } label: {
                 Label("Settings", systemImage: "gearshape.fill")
             }
         }
-        .labelStyle(.iconOnly)
+        .labelStyle(.titleAndIcon)
         .onAppear {
             if !hasCompletedOnboarding {
                 viewModel.showOnboarding = true
@@ -59,6 +59,7 @@ struct ContentView: View {
             }
         }
         .tint(accent.color)
+        .appBackground(accent: accent)
     }
 }
 

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -10,10 +10,10 @@ struct HomeDashboardView: View {
     @EnvironmentObject private var viewModel: ContentViewModel
     
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 28) {
-                    AppCard{
+                    AppCard {
                         VStack(alignment: .leading, spacing: 20) {
                             HStack(alignment: .top) {
                                 VStack(alignment: .leading, spacing: 6) {
@@ -71,7 +71,7 @@ struct HomeDashboardView: View {
                         .padding(.horizontal, AppStyle.horizontalPadding)
 
                         if viewModel.recentTools.isEmpty {
-                            AppCard{
+                            AppCard {
                                 Text("Jump back into tools and your history will live here.")
                                     .typography(.body, color: primary.opacity(0.65), design: .rounded)
                                     .frame(maxWidth: .infinity)
@@ -107,16 +107,9 @@ struct HomeDashboardView: View {
                     Spacer(minLength: 60)
                 }
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
             .navigationTitle("Home")
         }
+        .appBackground(accent: accent)
     }
 }
 

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -35,15 +35,15 @@ struct SettingsView: View {
     @AppStorage("Glass Effect activated") private var glassEffectActivated: Bool = true
     
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
                     appearanceSection
                     otherSection
                     aboutSection
-                    if #available(iOS 26, *){
-                        if experimentalEnabled{
-                            settingsBox{
+                    if #available(iOS 26, *) {
+                        if experimentalEnabled {
+                            settingsBox {
                                 Toggle("Glass Effect", isOn: $glassEffectActivated)
                             }
                         }
@@ -52,14 +52,6 @@ struct SettingsView: View {
                 }
                 .padding(.bottom, AppStyle.innerPadding)
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(content: {
@@ -74,6 +66,7 @@ struct SettingsView: View {
             })
             .animation(.linear, value: glassEffectActivated)
         }
+        .appBackground(accent: accent)
     }
 
     // MARK: - Sections
@@ -244,7 +237,7 @@ struct SettingsView: View {
     }
 
     private func settingsBox<Content: View>(@ViewBuilder content: @escaping () -> Content) -> some View {
-        AppCard{
+        AppCard {
             VStack(alignment: .leading, spacing: 16) {
                 content()
             }

--- a/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
@@ -12,13 +12,19 @@ import SwiftUI
 import Vision
 
 final class BgRemoverTool {
-    func removeBackground(from image: UIImage) async throws -> UIImage? {
-        guard let inputImage = CIImage(image: image) else {
+    private let context = CIContext(options: nil)
+
+    func removeBackground(from image: UIImage) async throws -> UIImage {
+        guard let inputImage = CIImage(image: image, options: [.applyOrientationProperty: true]) else {
             throw BgRemoverError.convertError
         }
         let maskImage = try createMask(from: inputImage)
         let outputImage = applyMask(mask: maskImage, to: inputImage)
-        return try convertToUIImage(ciImage: outputImage)
+        return try convertToUIImage(
+            ciImage: outputImage,
+            originalExtent: inputImage.extent,
+            scale: image.scale
+        )
     }
     
     private func createMask(from inputImage: CIImage) throws -> CIImage {
@@ -44,20 +50,20 @@ final class BgRemoverTool {
     
     private func applyMask(mask: CIImage, to image: CIImage) -> CIImage {
         let filter = CIFilter.blendWithMask()
-        
+
         filter.inputImage = image
         filter.maskImage = mask
         filter.backgroundImage = CIImage.empty()
-        
-        return filter.outputImage ?? image
+
+        return filter.outputImage?.cropped(to: image.extent) ?? image
     }
-    
-    private func convertToUIImage(ciImage: CIImage) throws -> UIImage {
-        guard let cgImage = CIContext(options: nil).createCGImage(ciImage, from: ciImage.extent) else {
+
+    private func convertToUIImage(ciImage: CIImage, originalExtent: CGRect, scale: CGFloat) throws -> UIImage {
+        guard let cgImage = context.createCGImage(ciImage, from: originalExtent) else {
             throw BgRemoverError.convertError
         }
-        
-        return UIImage(cgImage: cgImage)
+
+        return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
     }
 }
 

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -10,17 +10,17 @@ struct ToolsView: View {
     @Namespace private var namespace
     
     var body: some View {
-        NavigationStack{
+        NavigationStack {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 20) {
-                    if #available(iOS 26, *){
-                        GlassEffectContainer{
+                    if #available(iOS 26, *) {
+                        GlassEffectContainer {
                             ForEach(viewModel.toolManager.tools) { tool in
                                 ToolOverview(tool: tool)
                                     .environmentObject(viewModel)
                             }
                         }
-                    }else{
+                    } else {
                         ForEach(viewModel.toolManager.tools) { tool in
                             ToolOverview(tool: tool)
                                 .environmentObject(viewModel)
@@ -30,17 +30,9 @@ struct ToolsView: View {
                 .padding(.horizontal, AppStyle.horizontalPadding)
                 .padding(.vertical, AppStyle.innerPadding)
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-                .scaledToFill()
-            )
             .navigationTitle("Tools")
         }
+        .appBackground(accent: accent)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable `AppBackground` gradient helper and apply it across primary screens for consistent styling
- align card and tab presentation with shared style constants for a more coherent UI
- fix the background remover pipeline to respect image orientation and prevent cropped results

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6903f0800dd08320ab83a1b8c4a5effd