### PR TITLE
Simplify Resonans UI with system components

### DIFF
--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -7,41 +7,47 @@ struct ContentView: View {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @AppStorage("showGuidedTips") private var showGuidedTips = true
 
-    @Environment(\.colorScheme) private var colorScheme
-    
-    private var background: Color { AppStyle.background(for: colorScheme) }
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
+
+    @State private var homePath = NavigationPath()
+    @State private var toolsPath = NavigationPath()
 
     var body: some View {
         TabView(selection: $viewModel.selectedTab) {
-            Tab(value: .home, content: {
-                HomeDashboardView(accent: accent, primary: .primary)
+            NavigationStack(path: $homePath) {
+                HomeDashboardView()
                     .environmentObject(viewModel)
-            }, label: {
-                Label {
-                    Text("Home")
-                } icon: {
-                    Image("icon")
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 24, height: 24)
-                        .accessibilityHidden(true)
-                }
-            })
-            Tab(value: .tools, content: {
-                ToolsView(accent: accent, primary: .primary)
-                    .environmentObject(viewModel)
-            }, label: {
-                Label("Tools", systemImage: "wrench.and.screwdriver.fill")
-            })
-            Tab(value: .settings){
-                SettingsView()
-            }label: {
-                Label("Settings", systemImage: "gearshape.fill")
             }
+            .navigationDestination(for: ToolIdentifier.self) { identifier in
+                ToolDestinationView(toolIdentifier: identifier)
+                    .environmentObject(viewModel)
+            }
+            .tabItem {
+                Label("Home", systemImage: "house.fill")
+            }
+            .tag(TabSelection.home)
+
+            NavigationStack(path: $toolsPath) {
+                ToolsView()
+                    .environmentObject(viewModel)
+            }
+            .navigationDestination(for: ToolIdentifier.self) { identifier in
+                ToolDestinationView(toolIdentifier: identifier)
+                    .environmentObject(viewModel)
+            }
+            .tabItem {
+                Label("Tools", systemImage: "wrench.and.screwdriver")
+            }
+            .tag(TabSelection.tools)
+
+            NavigationStack {
+                SettingsView()
+            }
+            .tabItem {
+                Label("Settings", systemImage: "gearshape")
+            }
+            .tag(TabSelection.settings)
         }
-        .labelStyle(.iconOnly)
         .onAppear {
             if !hasCompletedOnboarding {
                 viewModel.showOnboarding = true

--- a/Resonans/Views/ContentView/ContentViewModel.swift
+++ b/Resonans/Views/ContentView/ContentViewModel.swift
@@ -14,12 +14,10 @@ final class ContentViewModel: ObservableObject {
     @Published var showOnboarding: Bool = false
     
     @Published var selectedTab: TabSelection = .home
-    @Published var selectedTool: ToolIdentifier? = nil
-    
     let toolManager: ToolManager = .shared
-    
+
     var favoriteToolIds: Set<ToolIdentifier> = []
-    var recentToolIDs: [ToolIdentifier] = []
+    @Published var recentToolIDs: [ToolIdentifier] = []
     
     var recentTools: [ToolItem] {
         recentToolIDs.compactMap { id in toolManager.tools.first(where: { $0.id == id }) }

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -1,135 +1,48 @@
 import SwiftUI
 
 struct HomeDashboardView: View {
-
-    let accent: AccentColorOption
-    let primary: Color
-    
-    @Environment(\.colorScheme) private var colorScheme
-    
     @EnvironmentObject private var viewModel: ContentViewModel
-    
-    var body: some View {
-        NavigationStack{
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 28) {
-                    AppCard{
-                        VStack(alignment: .leading, spacing: 20) {
-                            HStack(alignment: .top) {
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Welcome back")
-                                        .typography(.custom(size: 16, weight: .semibold), color: primary.opacity(0.7), design: .rounded)
-                                        .foregroundStyle(primary.opacity(0.7))
-                                    Text("Craft something brilliant today")
-                                        .typography(.custom(size: 30, weight: .heavy), color: primary, design: .rounded)
-                                }
-                                
-                                Spacer()
-                                
-                                VStack(spacing: 8) {
-                                    Image(systemName: "sparkles")
-                                        .typography(.custom(size: 26, weight: .bold), color: accent.color)
-                                    Text("v1.2")
-                                        .typography(.caption, color: primary.opacity(0.6), design: .rounded)
-                                }
-                            }
-                            
-                            Button {
-                                HapticsManager.shared.selection()
-                                viewModel.selectedTab = .tools
-                            } label: {
-                                HStack(spacing: 12) {
-                                    Image(systemName: "wrench.and.screwdriver")
-                                        .typography(.custom(size: 18, weight: .semibold))
-                                    Text("Browse tools")
-                                        .typography(.titleSmall, design: .rounded)
-                                }
-                                .foregroundStyle(accent.color)
-                                .frame(maxWidth: .infinity)
-                                .background(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .fill(accent.color.opacity(colorScheme == .dark ? 0.28 : 0.2))
-                                )
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                                        .stroke(accent.color.opacity(0.35), lineWidth: 1)
-                                )
-                                .shadow(color: accent.color.opacity(colorScheme == .dark ? 0.25 : 0.2), radius: 16, x: 0, y: 10)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        .padding(AppStyle.innerPadding)
-                    }
-                        .padding(.horizontal, AppStyle.horizontalPadding)
-                    
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack {
-                            Text("Recently used")
-                                .typography(.titleLarge, color: primary, design: .rounded)
-                            Spacer()
-                        }
-                        .padding(.horizontal, AppStyle.horizontalPadding)
 
-                        if viewModel.recentTools.isEmpty {
-                            AppCard{
-                                Text("Jump back into tools and your history will live here.")
-                                    .typography(.body, color: primary.opacity(0.65), design: .rounded)
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .padding(.horizontal, AppStyle.horizontalPadding)
-                        } else {
-                            VStack(spacing: 12) {
-                                ForEach(viewModel.recentTools.reversed()) { tool in
-                                    Button(disableGlassEffect: true){
-                                        HapticsManager.shared.selection()
-                                        Task{
-                                            viewModel.selectedTab = .tools
-                                            if viewModel.selectedTool == nil{
-                                                viewModel.selectedTool = tool.id
-                                            }else{
-                                                viewModel.selectedTool = nil
-                                                try! await Task.sleep(for: .nanoseconds(1))
-                                                viewModel.selectedTool = tool.id
-                                            }
-                                        }
-                                    } label: {
-                                        ToolOverview(tool: tool, presentedInHomeboard: true)
-                                            .environmentObject(viewModel)
-                                            .disabled(true)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                            }
-                            .padding(.horizontal, AppStyle.horizontalPadding)
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Welcome back")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Text("Craft something brilliant today")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                    Button {
+                        viewModel.selectedTab = .tools
+                    } label: {
+                        Label("Browse tools", systemImage: "wrench.and.screwdriver")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Section("Recently used") {
+                if viewModel.recentTools.isEmpty {
+                    Text("Run any tool to see it here.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.recentTools.reversed()) { tool in
+                        NavigationLink(value: tool.id) {
+                            ToolListRow(tool: tool)
                         }
                     }
-                    
-                    Spacer(minLength: 60)
                 }
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-            )
-            .navigationTitle("Home")
         }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Home")
     }
 }
 
 #Preview {
-    struct PreviewWrapper: View {
-        @State private var trigger = false
-        let tools = ToolManager.shared.tools
-        var body: some View {
-            HomeDashboardView(
-                accent: .purple,
-                primary: .black
-            )
-        }
-    }
-    return PreviewWrapper()
+    HomeDashboardView()
+        .environmentObject(ContentViewModel())
 }

--- a/Resonans/Views/Tools/ToolDestinationView.swift
+++ b/Resonans/Views/Tools/ToolDestinationView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ToolDestinationView: View {
+    let toolIdentifier: ToolIdentifier
+    @EnvironmentObject private var viewModel: ContentViewModel
+
+    var body: some View {
+        toolIdentifier.destination
+            .onAppear {
+                viewModel.recentToolIDs.removeAll { $0 == toolIdentifier }
+                viewModel.recentToolIDs.append(toolIdentifier)
+            }
+    }
+}

--- a/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverTool.swift
@@ -18,7 +18,7 @@ final class BgRemoverTool {
         }
         let maskImage = try createMask(from: inputImage)
         let outputImage = applyMask(mask: maskImage, to: inputImage)
-        return try convertToUIImage(ciImage: outputImage)
+        return try convertToUIImage(ciImage: outputImage, original: image)
     }
     
     private func createMask(from inputImage: CIImage) throws -> CIImage {
@@ -52,12 +52,12 @@ final class BgRemoverTool {
         return filter.outputImage ?? image
     }
     
-    private func convertToUIImage(ciImage: CIImage) throws -> UIImage {
+    private func convertToUIImage(ciImage: CIImage, original: UIImage) throws -> UIImage {
         guard let cgImage = CIContext(options: nil).createCGImage(ciImage, from: ciImage.extent) else {
             throw BgRemoverError.convertError
         }
-        
-        return UIImage(cgImage: cgImage)
+
+        return UIImage(cgImage: cgImage, scale: original.scale, orientation: original.imageOrientation)
     }
 }
 

--- a/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverView.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/BgRemoverView.swift
@@ -10,190 +10,109 @@ import PhotosUI
 
 struct BgRemoverView: View {
     @StateObject var viewModel: BgRemoverViewModel
-    @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
-    @State var showAllRecents: Bool = false
-    @Namespace var animation
 
-    private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
-    
     init(viewModel: BgRemoverViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
     
     var body: some View {
-        ZStack {
-            if viewModel.useFullScreenSheet {
-                cameraView
-                    .swipeToDismiss($viewModel.useFullScreenSheet)
-            } else {
-                ScrollView {
-                    VStack(spacing: 24) {
-                        headerSection
-                        sourceSection
-                        recentSection
-                    }
-                    .padding(.horizontal, 24)
-                }
-                .sheet(item: $viewModel.activeSheet) { type in
-                    switch type {
-                    case .photoLibrary:
-                        PhotoLibraryPicker(
-                            config: .init(
-                                selectionLimit: 1,
-                                filter: .images
-                            ) { urls in
-                                guard let firstUrl = urls.first else { return }
-                                viewModel.handleImageFromPhotoPicker(url: firstUrl)
-                            }
-                        )
-                    case .recents(let url):
-                        ExportPicker(url: url)
-                    case .tool(let image):
-                        RemoveBackgroundView(image: image)
-                    case .cameraNotAuthorized(let status):
-                        AllowCameraSheet(status: status)
-                    }
-                }
-                .background(
-                    LinearGradient(
-                        colors: [accent.gradient, .clear],
-                        startPoint: .topLeading,
-                        endPoint: .bottom
-                    )
-                    .ignoresSafeArea()
-                )
-            }
-        }
-    }
-    
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Background Remover")
-                .typography(.titleMedium, color: .primary.opacity(0.7), design: .rounded)
-            HStack {
-                Text("Removes background from your images")
-                    .typography(.displaySmall, design: .rounded)
-                Spacer()
-                Image(systemName: "photo.on.rectangle.angled")
-                    .typography(.custom(size: 30, weight: .bold), color: accent.color)
-            }
-        }
-        .padding(.top, 24)
-    }
-    
-    private var sourceSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Choose a source")
-                .typography(.titleMedium, design: .rounded)
+        List {
+            Section("Get started") {
+                Text("Remove backgrounds from your images using the camera or your photo library.")
+                    .foregroundStyle(.secondary)
 
-            HStack(spacing: 16) {
-                sourceOptionCard(icon: "camera", title: "Take from Camera") {
+                Button {
                     viewModel.handleOpenCamera()
+                } label: {
+                    Label("Capture photo", systemImage: "camera")
                 }
-                .matchedGeometryEffect(id: "camera", in: animation, isSource: false)
 
-                sourceOptionCard(icon: "photo.on.rectangle", title: "Pick from Photo Library") {
+                Button {
                     viewModel.showPhotoLibrary()
+                } label: {
+                    Label("Choose from library", systemImage: "photo.on.rectangle")
                 }
             }
-        }
-    }
-    
-    private var recentSection: some View {
-        AppCard {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Recent conversions")
-                    .typography(.titleLarge, design: .rounded)
-                    .padding(.top, 16)
-                    .padding(.horizontal, 12)
-                
-                VStack(spacing: 12) {
-                    if viewModel.recents.isEmpty {
-                        Text("No exports yet")
-                            .typography(.titleSmall, color: .primary.opacity(0.7), design: .rounded)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.vertical, 40)
-                    } else {
-                        let prefixCount = showAllRecents ? viewModel.recents.count : 3
-                        let recents = Array(viewModel.recents.prefix(prefixCount))
 
-                        ForEach(recents.indices, id: \.self) { index in
-                            let item = recents[index]
-                            VStack(spacing: 12) {
-                                RecentRow(item: item, onSave: viewModel.handleRecentExport)
-                                    .padding(.horizontal, 12)
-                                
-                                if index < recents.count - 1 {
-                                    Divider()
-                                        .padding(.leading, 12)
-                                }
-                            }
-                        }
-                        
-                        if viewModel.recents.count > 3 {
-                            Button {
-                                HapticsManager.shared.pulse()
-                                withAnimation(.easeInOut(duration: 0.25)) {
-                                    showAllRecents.toggle()
-                                }
-                            } label: {
-                                Text(showAllRecents ? "Show less" : "Show more")
-                                    .typography(.bodyBold, color: .primary.opacity(0.75), design: .rounded)
-                            }
-                            .padding(.top, 6)
+            Section("Recent conversions") {
+                if viewModel.recents.isEmpty {
+                    Text("You'll see your converted images here.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.recents) { item in
+                        RecentConversionRow(item: item) {
+                            viewModel.handleRecentExport(item)
                         }
                     }
                 }
-                .padding(.top, 12)
-                .padding(.bottom, 18)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-    
-    private func sourceOptionCard(icon: String, title: String, action: @escaping () -> Void) -> some View {
-        Button(disableGlassEffect: true){
-            HapticsManager.shared.pulse()
-            action()
-        } label: {
-            AppCard {
-                VStack(spacing: 12) {
-                    Image(systemName: icon)
-                        .typography(.custom(size: 30, weight: .semibold))
-                    Text(title)
-                        .typography(.titleSmall, design: .rounded)
-                        .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 24)
             }
         }
-        .buttonStyle(.plain)
-    }
-    
-    private var cameraView: some View {
-        BgRemoverCameraView(
-            cameraManager: CameraManager.shared,
-            onPhotoCaptured: { image in
-                withAnimation(.spring(duration: 0.3)) {
+        .listStyle(.insetGrouped)
+        .navigationTitle("Background remover")
+        .task { viewModel.reloadRecents() }
+        .sheet(item: $viewModel.activeSheet) { type in
+            switch type {
+            case .photoLibrary:
+                PhotoLibraryPicker(
+                    config: .init(
+                        selectionLimit: 1,
+                        filter: .images
+                    ) { urls in
+                        guard let firstUrl = urls.first else { return }
+                        viewModel.handleImageFromPhotoPicker(url: firstUrl)
+                    }
+                )
+            case .recents(let url):
+                ExportPicker(url: url)
+            case .tool(let image):
+                RemoveBackgroundView(image: image)
+            case .cameraNotAuthorized(let status):
+                AllowCameraSheet(status: status)
+            }
+        }
+        .fullScreenCover(isPresented: $viewModel.useFullScreenSheet) {
+            BgRemoverCameraView(
+                cameraManager: CameraManager.shared,
+                onPhotoCaptured: { image in
                     viewModel.useFullScreenSheet = false
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     viewModel.handleImageFromPhotoLibrary(image)
-                }
-            },
-            onClose: {
-                withAnimation(.spring(duration: 0.3)) {
+                },
+                onClose: {
                     viewModel.useFullScreenSheet = false
                 }
-            }
-        )
-        .background {
-            Color.clear
-                .matchedGeometryEffect(id: "camera", in: animation)
+            )
         }
-        .transition(.opacity)
-        .zIndex(1)
+    }
+}
+
+private struct RecentConversionRow: View {
+    let item: RecentItem
+    let onExport: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.headline)
+                Text(item.duration)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            ShareLink(item: item.fileURL) {
+                Image(systemName: "square.and.arrow.up")
+                    .imageScale(.medium)
+            }
+            .buttonStyle(.plain)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(action: onExport) {
+                Label("Save", systemImage: "tray.and.arrow.down")
+            }
+            .tint(.accentColor)
+        }
     }
 }
 

--- a/Resonans/Views/Tools/ToolItems/BgRemover/RemoveBackground/RemoveBackgroundView.swift
+++ b/Resonans/Views/Tools/ToolItems/BgRemover/RemoveBackground/RemoveBackgroundView.swift
@@ -9,35 +9,53 @@ import SwiftUI
 
 struct RemoveBackgroundView: View {
     @StateObject var viewModel: RemoveBackgroundViewModel
-    
+
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("accentColor") private var accentRaw = AccentColorOption.purple.rawValue
-    @State var activeSheet: ActiveSheet?
+    @State private var activeSheet: ActiveSheet?
+
     private var accent: AccentColorOption { AccentColorOption(rawValue: accentRaw) ?? .purple }
-    
+
     init(image: UIImage) {
-        self._viewModel = StateObject(wrappedValue: RemoveBackgroundViewModel(image: image))
+        _viewModel = StateObject(wrappedValue: RemoveBackgroundViewModel(image: image))
     }
-    
+
     var body: some View {
-        VStack {
-            headerSection
-            imageSection
-            Spacer()
-            footerButton
+        NavigationStack {
+            Form {
+                Section("Preview") {
+                    VStack(alignment: .center, spacing: 16) {
+                        Image(uiImage: viewModel.image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+                        if viewModel.isLoading {
+                            ProgressView("Processing…")
+                                .progressViewStyle(.circular)
+                        }
+                    }
+                    .listRowInsets(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
+                }
+
+                Section {
+                    Button(action: viewModel.removeBackground) {
+                        Text(viewModel.isLoading ? "Converting…" : "Remove background")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .disabled(viewModel.isLoading)
+                }
+            }
+            .navigationTitle("Remove background")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done", action: dismiss.callAsFunction)
+                }
+            }
         }
-        .presentationDetents([.medium])
-        .padding(.top, 12)
-        .padding(.horizontal, 24)
-        .background(
-            LinearGradient(
-                colors: [accent.gradient, colorScheme == .dark ? .black : .white],
-                startPoint: .topLeading,
-                endPoint: .bottom
-            )
-            .ignoresSafeArea()
-        )
+        .tint(accent.color)
+        .presentationDetents([.medium, .large])
         .onChange(of: viewModel.errorMessage) { oldError, newError in
             if let newError, oldError != newError, !newError.isEmpty {
                 activeSheet = .removeFailed(errorMessage: newError)
@@ -49,11 +67,11 @@ struct RemoveBackgroundView: View {
         }
         .sheet(item: $activeSheet) { type in
             switch type {
-            case .removeFailed(_):
+            case .removeFailed:
                 ConversionFailSheet(
                     accentColor: accent.color,
                     primaryColor: .primary,
-                    onRetry: {},
+                    onRetry: viewModel.removeBackground,
                     onDone: { activeSheet = nil }
                 )
             case .removeSuccess(let image):
@@ -61,77 +79,19 @@ struct RemoveBackgroundView: View {
             }
         }
     }
-    
-    private var headerSection: some View {
-        HStack {
-            Text("Background")
-                .typography(.displayMedium, design: .rounded)
-            Spacer()
-            Button(action: {
-                HapticsManager.shared.selection()
-                dismiss()
-            }) {
-                AppCard(isMaxWidth: false) {
-                    Text("Done")
-                        .typography(.titleSmall, design: .rounded)
-                }
-            }
-        }
-    }
-    
-    private var imageSection: some View {
-        AppCard {
-            VStack {
-                Image(uiImage: viewModel.image)
-                    .resizable()
-                    .scaledToFit()
-                Text("Image")
-                    .typography(.titleLarge)
-            }
-        }
-        .frame(width: 250)
-    }
-    
-    private var footerButton: some View {
-        Button(action: viewModel.removeBackground) {
-            Text("Convert")
-                .padding(.vertical, 16)
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .fill(accent.color.opacity(viewModel.isLoading ? 0.65 : 1))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppStyle.cornerRadius, style: .continuous)
-                        .stroke(accent.color.opacity(0.35), lineWidth: 1)
-                )
-                .shadow(color: accent.color.opacity(0.3), radius: 16, x: 0, y: 10)
-        }
-        .buttonStyle(.plain)
-        .disabled(viewModel.isLoading)
-    }
 }
 
 extension RemoveBackgroundView {
     enum ActiveSheet: Identifiable {
         case removeFailed(errorMessage: String)
         case removeSuccess(image: UIImage)
+
         var id: String { String(describing: self) }
     }
 }
 
 #Preview {
-    struct Preview: View {
-        @State var isShown: Bool = true
-        
-        var body: some View {
-            Button("Show Sheet") {
-                isShown = true
-            }
-            .sheet(isPresented: $isShown) {
-                RemoveBackgroundView(image: .logo)
-            }
-        }
+    NavigationStack {
+        RemoveBackgroundView(image: .logo)
     }
-    return Preview()
 }

--- a/Resonans/Views/Tools/ToolListRow.swift
+++ b/Resonans/Views/Tools/ToolListRow.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ToolListRow: View {
+    let tool: ToolItem
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(tool.title)
+                    .font(.headline)
+                Text(tool.subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: tool.iconName)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.accentColor)
+                .frame(width: 28, height: 28)
+        }
+        .labelStyle(.toolLeadingIcon)
+    }
+}
+
+private extension LabelStyle where Self == ToolLeadingIconLabelStyle {
+    static var toolLeadingIcon: ToolLeadingIconLabelStyle { ToolLeadingIconLabelStyle() }
+}
+
+private struct ToolLeadingIconLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            configuration.icon
+                .font(.title2)
+            configuration.title
+        }
+    }
+}
+
+#Preview {
+    ToolListRow(tool: .init(id: .bgRemover,
+                            title: "Background Remover",
+                            subtitle: "Remove backgrounds in seconds.",
+                            iconName: "photo",
+                            gradientHex: []))
+}

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -1,61 +1,24 @@
 import SwiftUI
 
 struct ToolsView: View {
-    let accent: AccentColorOption
-    let primary: Color
-    @Environment(\.colorScheme) private var colorScheme
-    
     @EnvironmentObject private var viewModel: ContentViewModel
-    
-    @Namespace private var namespace
-    
+
     var body: some View {
-        NavigationStack{
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 20) {
-                    if #available(iOS 26, *){
-                        GlassEffectContainer{
-                            ForEach(viewModel.toolManager.tools) { tool in
-                                ToolOverview(tool: tool)
-                                    .environmentObject(viewModel)
-                            }
-                        }
-                    }else{
-                        ForEach(viewModel.toolManager.tools) { tool in
-                            ToolOverview(tool: tool)
-                                .environmentObject(viewModel)
-                        }
+        List {
+            Section("All tools") {
+                ForEach(viewModel.toolManager.tools) { tool in
+                    NavigationLink(value: tool.id) {
+                        ToolListRow(tool: tool)
                     }
                 }
-                .padding(.horizontal, AppStyle.horizontalPadding)
-                .padding(.vertical, AppStyle.innerPadding)
             }
-            .background(
-                LinearGradient(
-                    colors: [accent.gradient, .clear],
-                    startPoint: .topLeading,
-                    endPoint: .bottom
-                )
-                .ignoresSafeArea()
-                .scaledToFill()
-            )
-            .navigationTitle("Tools")
         }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Tools")
     }
 }
 
 #Preview {
-    struct PreviewWrapper: View {
-        @State private var selected: ToolIdentifier? = .audioExtractor
-        @State private var trigger = false
-
-        var body: some View {
-            ToolsView(
-                accent: .purple,
-                primary: .black
-            )
-        }
-    }
-    return PreviewWrapper()
+    ToolsView()
         .environmentObject(ContentViewModel())
 }


### PR DESCRIPTION
## Summary
- replace custom tab layout with NavigationStacks and shared tool navigation
- redesign the home and tools screens to use SwiftUI lists and reusable rows for consistent styling
- streamline the background remover workflow, including a Form-based sheet and preserving image orientation during export

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6903f3dde4d88320ab6d4d508fe28fd1