### PR TITLE
Document code with Xcode-style comments

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,34 @@
+# Resonans codebase overview
+
+This document describes the structure and responsibilities of the Resonans iOS app so contributors can quickly navigate the code.
+
+## Top-level layout
+- `ResonansApp.swift` boots the SwiftUI application, wires the shared `ContentViewModel`, and applies the user-selected appearance via `@AppStorage`.
+- `Views/` contains the SwiftUI screens: the tab shell (`ContentView`), home dashboard, tools catalog, settings, and onboarding flow.
+- `Models/` defines lightweight data types such as tool definitions, app storage keys, and recently exported items.
+- `DataSources/` holds singleton managers for tool registration and cache/recents persistence.
+- `Utilities/`, `Components/`, and `OSFeatures/` provide reusable UI building blocks, styling constants, and platform integrations (e.g., haptics).
+
+## Application flow
+- **Entry point:** `ResonansApp` constructs `ContentView` inside a `WindowGroup`, injects `ContentViewModel`, and restores the persisted appearance. On launch it preloads favorite tools from `UserDefaults` so the UI can render with correct badges and sections immediately.
+- **Tabs and routing:** `ContentView` drives the three-tab layout (Home, Tools, Settings) using `@Published` selection in `ContentViewModel`. It also presents onboarding as a full-screen cover until the user completes it, persisting choices for accent color and guided tips.
+
+## Data and state
+- **Tool registry:** `ToolManager` is a singleton that lazily loads the available `ToolItem` definitions from hard-coded identifiers, exposing them via a published array for SwiftUI bindings.
+- **Tool metadata:** `ToolIdentifier` enumerates the supported tools and builds the corresponding `ToolItem` (title, subtitle, icon, gradient, beta flag, default favorite) plus the navigation destination view for each tool.
+- **Caching and recents:** `CacheManager` centralizes cache directory creation, clearing, and persistence of recent tools and conversion outputs. It stores recent conversions as `RecentItem` values, ensures file existence, trims history, and posts an update notification after writes.
+- **Session state:** `ContentViewModel` tracks the active tab, selected tool, favorites set, and recently used tool identifiers. It exposes helper methods to hydrate favorites from storage and derive the recent tool list from identifiers.
+
+## Feature surfaces
+- **Home dashboard:** `HomeDashboardView` welcomes the user, links to tool browsing, and highlights favorites and recent tools. Buttons update the shared view model to open the selected tool tab and remember the last-used tool for quick reentry.
+- **Tools catalog:** `ToolsView` lists tools with search and favorite prioritization. `ToolOverview` renders each card, handles favoriting persistence, and routes to the tool-specific destination while tracking recents in the shared view model.
+- **Onboarding:** `OnboardingFlowView` walks users through feature highlights, favorite selection, workflow preference, and optional guided tips. Completion returns the chosen favorites and tips flag to `ContentView` to persist and dismiss onboarding.
+- **Settings:** `SettingsView` allows appearance/accent selection, toggles haptics/sounds/experimental flags, reopens onboarding, and triggers cache clearing through `CacheManager`. Experimental toggles are surfaced when enabled.
+
+## UI and platform utilities
+- **Styling:** `StyleConstants.swift` (via `AppStyle`) centralizes spacing, corner radii, stroke/fill opacities, and background helpers used across views.
+- **Haptics:** `HapticsManager` wraps `UIImpactFeedbackGenerator`, `UISelectionFeedbackGenerator`, and `UINotificationFeedbackGenerator`, gating feedback based on the persisted haptics setting.
+- **Shared components:** Reusable views such as `AppCard`, `GlassButton`, `ToolIconView`, shimmer/mesh gradients, and swipe-dismiss helpers live under `Utilities/` and `Components/`, keeping feature screens lean.
+
+## Persistence keys and options
+- `AppStorageKey` and related enums (e.g., `Appearance`, `AccentColorOption`) define the keys used with `@AppStorage` for appearance, accent color, onboarding completion, guided tips, haptics, sounds, and experimental feature flags. Settings and onboarding views rely on these to stay in sync with user defaults.

--- a/Resonans/Components/GlassButton.swift
+++ b/Resonans/Components/GlassButton.swift
@@ -4,23 +4,28 @@
 
 import SwiftUI
 
+/// A SwiftUI button that optionally adopts the system glass style on supported OS versions.
 struct GlassButton<Label: View>: View {
+    /// Action triggered when the button is tapped.
     var action: () -> Void
+    /// Content builder for the button label.
     @ViewBuilder var label: () -> Label
     
     @AppStorage(AppStorageKey.Settings.glassEffectActivated) private var glassEffectActivated: Bool = true
     
     private let disableGlassEffect: Bool
     
+    /// Creates a button with a custom label builder.
     init(disableGlassEffect: Bool = false, action: @escaping () -> Void, label: @escaping () -> Label) {
         self.action = action
         self.label = label
         self.disableGlassEffect = disableGlassEffect
     }
-    
+
+    /// Convenience initializer for text-only buttons.
     init(_ title: String, disableGlassEffect: Bool = false, action: @escaping () -> Void) where Label == Text {
         self.action = action
-        self.label = { Text(title) }        
+        self.label = { Text(title) }
         self.disableGlassEffect = disableGlassEffect
     }
     

--- a/Resonans/Components/RecentRow.swift
+++ b/Resonans/Components/RecentRow.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
+/// Displays a converted item with quick actions for sharing or saving.
 struct RecentRow: View {
+    /// Model describing the exported file.
     let item: RecentItem
+    /// Callback fired when the user chooses to save the file to disk.
     let onSave: (RecentItem) -> Void
 
     @Environment(\.colorScheme) private var colorScheme

--- a/Resonans/Components/Sheets/ConversionFailSheet.swift
+++ b/Resonans/Components/Sheets/ConversionFailSheet.swift
@@ -7,10 +7,15 @@
 
 import SwiftUI
 
+/// Presents an error sheet when a media conversion fails.
 struct ConversionFailSheet: View {
+    /// Accent color used for buttons and highlights.
     let accentColor: Color
+    /// Primary text color that adapts to the current theme.
     let primaryColor: Color
+    /// Callback invoked when the user wants to retry.
     let onRetry: () -> Void
+    /// Callback invoked when the user dismisses the sheet.
     let onDone: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -138,6 +143,7 @@ struct ConversionFailSheet: View {
     }
 
     // MARK: - Helpers
+    /// Builds the stylized capsule button label used across actions.
     private func capsuleLabel(title: String, systemImage: String, foreground: Color) -> some View {
         HStack {
             Spacer()
@@ -148,6 +154,7 @@ struct ConversionFailSheet: View {
         .padding(.vertical, 14)
     }
 
+    /// Drives the sequential halo and symbol animation.
     private func startAnimation() {
         animateError = false
         showHalo = false
@@ -168,6 +175,7 @@ struct ConversionFailSheet: View {
         }
     }
 
+    /// Handles retry taps with a haptic selection callback.
     private func handleRetryTapped() {
         HapticsManager.shared.selection()
         onRetry()

--- a/Resonans/Components/Sheets/ConversionSuccessSheet.swift
+++ b/Resonans/Components/Sheets/ConversionSuccessSheet.swift
@@ -7,11 +7,17 @@
 
 import SwiftUI
 
+/// Presents a confirmation sheet after a successful conversion.
 struct ConversionSuccessSheet: View {
+    /// Location of the exported media for sharing and saving.
     let exportURL: URL
+    /// Accent color used for primary actions.
     let accentColor: Color
+    /// Primary text color that responds to theme changes.
     let primaryColor: Color
+    /// Callback fired when the user chooses to save the file locally.
     let onSave: () -> Void
+    /// Callback fired when the sheet is dismissed.
     let onDone: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -133,6 +139,7 @@ struct ConversionSuccessSheet: View {
         .ignoresSafeArea()
     }
 
+    /// Builds the consistent capsule-styled label shared by both buttons.
     private func capsuleLabel(title: String, systemImage: String, foreground: Color) -> some View {
         HStack {
             Spacer()
@@ -143,6 +150,7 @@ struct ConversionSuccessSheet: View {
         .padding(.vertical, 14)
     }
 
+    /// Drives the halo and checkmark entrance animation.
     private func startAnimation() {
         animateCheck = false
         showHalo = false
@@ -163,6 +171,7 @@ struct ConversionSuccessSheet: View {
         }
     }
 
+    /// Triggers haptics and forwards the save action.
     private func handleSaveTapped() {
         HapticsManager.shared.selection()
         onSave()

--- a/Resonans/DataSources/CacheManager.swift
+++ b/Resonans/DataSources/CacheManager.swift
@@ -1,6 +1,13 @@
 import Foundation
 
+/// Handles temporary storage for exports and persisted recents lists.
+///
+/// The manager stores metadata in JSON files inside the caches directory and
+/// moves exported media into an "exports" subfolder. It also posts
+/// ``Notification.Name.recentConversionsDidUpdate`` when the recents list
+/// changes so UI can refresh.
 final class CacheManager {
+    /// Shared singleton used across view models.
     static let shared = CacheManager()
 
     private let fileManager = FileManager.default
@@ -36,6 +43,7 @@ final class CacheManager {
 
     // MARK: - Recent tools
 
+    /// Loads the recently opened tool identifiers from disk.
     func loadRecentTools() -> [ToolIdentifier] {
         guard let data = try? Data(contentsOf: recentToolsURL) else { return [] }
         guard let rawIDs = try? decoder.decode([String].self, from: data) else {
@@ -45,6 +53,7 @@ final class CacheManager {
         return rawIDs.compactMap { ToolIdentifier(rawValue: $0) }
     }
 
+    /// Persists the provided tool identifiers, trimming to the allowed limit.
     func saveRecentTools(_ identifiers: [ToolIdentifier]) {
         let trimmed = Array(identifiers.prefix(maxRecentTools))
         let raw = trimmed.map { $0.rawValue }
@@ -54,6 +63,7 @@ final class CacheManager {
 
     // MARK: - Recent conversions
 
+    /// Returns recent conversions that still exist on disk, removing stale entries.
     func loadRecentConversions() -> [RecentItem] {
         guard let data = try? Data(contentsOf: recentConversionsURL) else { return [] }
         guard let decoded = try? decoder.decode([RecentItem].self, from: data) else {
@@ -69,6 +79,14 @@ final class CacheManager {
     }
 
     @discardableResult
+    /// Moves a temporary export into the cache directory and records it as recent.
+    ///
+    /// - Parameters:
+    ///   - title: User-facing name of the conversion.
+    ///   - duration: Duration string to display next to the item.
+    ///   - tempURL: Temporary file location created by the converter.
+    /// - Returns: The newly created ``RecentItem`` for UI display.
+    /// - Throws: Any file system errors encountered while moving or writing.
     func recordConversion(title: String, duration: String, tempURL: URL) throws -> RecentItem {
         createDirectoriesIfNeeded()
 
@@ -103,11 +121,13 @@ final class CacheManager {
 
     // MARK: - Helpers
 
+    /// Encodes the recents list to disk.
     private func saveRecentConversions(_ items: [RecentItem]) {
         guard let data = try? encoder.encode(items) else { return }
         try? data.write(to: recentConversionsURL, options: .atomic)
     }
 
+    /// Generates a unique output destination inside the exports directory.
     private func uniqueDestination(for url: URL) throws -> URL {
         let baseName = url.deletingPathExtension().lastPathComponent
         let ext = url.pathExtension
@@ -121,6 +141,7 @@ final class CacheManager {
         return candidate
     }
 
+    /// Ensures the base cache and exports directories exist.
     private func createDirectoriesIfNeeded() {
         if !fileManager.fileExists(atPath: baseDirectory.path) {
             try? fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)

--- a/Resonans/DataSources/ToolManager.swift
+++ b/Resonans/DataSources/ToolManager.swift
@@ -8,17 +8,25 @@
 import Combine
 import Foundation
 
+/// Loads and exposes the list of available tools for the app.
+///
+/// The manager currently builds tools from a static list of identifiers, but
+/// the structure allows expanding to remote configuration later. It is shared
+/// as a singleton to keep tool metadata consistent across tabs.
 final class ToolManager: ObservableObject {
+    /// Shared instance consumed by view models.
     static var shared = ToolManager()
-    
+
+    /// Published array of tools displayed throughout the UI.
     @Published var tools: [ToolItem] = []
-    
+
     private init() {
         loadTools()
     }
-    
+
     private let localToolIdentifiers: [ToolIdentifier] = [.audioExtractor, .bgRemover, .editor]
-    
+
+    /// Populates ``tools`` from the local identifier list.
     private func loadTools() {
         let localTools = localToolIdentifiers.map { $0.tool }
         self.tools = localTools

--- a/Resonans/FilePicker.swift
+++ b/Resonans/FilePicker.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Wraps `UIDocumentPickerViewController` to select movie files.
 struct FilePicker: UIViewControllerRepresentable {
+    /// Completion handler returning the chosen file URL.
     var onComplete: (URL) -> Void
     func makeCoordinator() -> Coordinator { Coordinator(onComplete: onComplete) }
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {

--- a/Resonans/Models/AppNewsItem.swift
+++ b/Resonans/Models/AppNewsItem.swift
@@ -1,11 +1,18 @@
 import Foundation
 
+/// Represents a single announcement displayed in the app's news feed.
+///
+/// Each item is identified by a generated `UUID` and includes a title,
+/// description, and publication date. The `formattedDate` helper renders
+/// the date using the user’s locale-friendly medium style to match the
+/// rest of the interface.
 struct AppNewsItem: Identifiable {
     let id = UUID()
     let title: String
     let description: String
     let date: Date
 
+    /// Returns the localized display string for the publication date.
     var formattedDate: String {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium

--- a/Resonans/Models/AppStorageKey.swift
+++ b/Resonans/Models/AppStorageKey.swift
@@ -5,6 +5,7 @@
 //  Created by Kevin Dallian on 03/11/25.
 //
 
+/// Centralized collection of `@AppStorage` keys used throughout the app.
 struct AppStorageKey {
     // MARK: - Onboarding
     struct Onboarding {
@@ -13,6 +14,7 @@ struct AppStorageKey {
     }
 
     // MARK: - Settings
+    /// Keys that persist user preferences in the settings tab.
     struct Settings {
         static let appearance = "appearance"
         static let accentColor = "accentColor"

--- a/Resonans/Models/AuthorizationStatus.swift
+++ b/Resonans/Models/AuthorizationStatus.swift
@@ -5,11 +5,13 @@
 //  Created by Kevin Dallian on 30/10/25.
 //
 
+/// Simplified representation of privacy authorization states used by the app.
 enum AuthorizationStatus: String, Identifiable {
     case notDetermined
     case restricted
     case denied
     case authorized
     
+    /// String identifier to satisfy `Identifiable` conformance for SwiftUI.
     var id: String { String(describing: self) }
 }

--- a/Resonans/Models/RecentItem.swift
+++ b/Resonans/Models/RecentItem.swift
@@ -1,10 +1,21 @@
 import Foundation
 
+/// Describes a previously exported file so it can be surfaced in "Recents".
+///
+/// The type is codable for persistence on disk and equatable so duplicates
+/// can be filtered out when merging saved results. Each entry stores the
+/// human-readable title and duration alongside the final file URL path and
+/// its creation date.
 struct RecentItem: Identifiable, Codable, Equatable {
+    /// Stable identifier used for SwiftUI lists and persistence.
     let id: UUID
+    /// User-facing title describing the export.
     let title: String
+    /// Duration string displayed in the UI (e.g., formatted minutes/seconds).
     let duration: String
+    /// Absolute path to the exported media file.
     let filePath: String
+    /// Timestamp representing when the export finished.
     let createdAt: Date
 
     init(
@@ -21,6 +32,7 @@ struct RecentItem: Identifiable, Codable, Equatable {
         self.createdAt = createdAt
     }
 
+    /// Convenience accessor that converts the stored path into a URL.
     var fileURL: URL {
         URL(fileURLWithPath: filePath)
     }

--- a/Resonans/Models/Settings.swift
+++ b/Resonans/Models/Settings.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Represents the app's appearance override options.
 enum Appearance: String, CaseIterable, Identifiable {
     case light
     case dark
@@ -7,6 +8,7 @@ enum Appearance: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Human-readable text used in settings pickers.
     var label: String {
         switch self {
         case .light: return "Light"
@@ -15,6 +17,7 @@ enum Appearance: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Maps the selection to an optional SwiftUI `ColorScheme` override.
     var colorScheme: ColorScheme? {
         switch self {
         case .light: return .light
@@ -24,6 +27,7 @@ enum Appearance: String, CaseIterable, Identifiable {
     }
 }
 
+/// Enumerates accent color choices exposed to the user.
 enum AccentColorOption: String, CaseIterable, Identifiable {
     case blue
     case green
@@ -34,6 +38,7 @@ enum AccentColorOption: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Materializes the concrete `Color` for the option.
     var color: Color {
         switch self {
         case .blue: return .blue
@@ -45,6 +50,7 @@ enum AccentColorOption: String, CaseIterable, Identifiable {
         }
     }
 
+    /// A softer variant of the accent color for backgrounds and gradients.
     var gradient: Color {
         color.opacity(0.25)
     }

--- a/Resonans/Models/ToolItem.swift
+++ b/Resonans/Models/ToolItem.swift
@@ -1,20 +1,34 @@
 import SwiftUI
 
+/// Describes a single tool surfaced in the app, including metadata for UI rendering.
+///
+/// Each tool is backed by a ``ToolIdentifier`` and provides the display title,
+/// subtitle, symbol name, and gradient colors used for its card. Flags indicate
+/// whether the tool is in beta and if it should appear as a default favorite.
 struct ToolItem: Identifiable {
+    /// Stable identifier used for lookups and navigation.
     let id: ToolIdentifier
+    /// Primary label shown on the tool tile.
     let title: String
+    /// Supporting description that clarifies the tool’s purpose.
     let subtitle: String
+    /// SF Symbol name rendered in the tool card.
     let iconName: String
+    /// Two-color gradient expressed as hex strings.
     let gradientHex: [String]
+    /// Indicates the feature is still in beta.
     let beta: Bool
+    /// Marks the tool as a pinned favorite on first launch.
     let favorite: Bool
 }
 
+/// Known tools that the app ships with and their associated navigation targets.
 enum ToolIdentifier: String, Hashable {
     case audioExtractor
     case bgRemover
     case editor
     
+    /// Builds the ``ToolItem`` metadata associated with the identifier.
     var tool: ToolItem {
         switch self {
         case .audioExtractor:
@@ -50,6 +64,7 @@ enum ToolIdentifier: String, Hashable {
         }
     }
     
+    /// Resolves the SwiftUI destination for the tool.
     @ViewBuilder
     var destination: some View {
         switch self {

--- a/Resonans/OSFeatures/Camera/CameraManager.swift
+++ b/Resonans/OSFeatures/Camera/CameraManager.swift
@@ -10,7 +10,9 @@ import Combine
 import Foundation
 import UIKit
 
+/// Manages camera capture configuration, authorization, and photo capture.
 final class CameraManager: NSObject, ObservableObject {
+    /// Shared singleton used by the background remover and other features.
     static let shared: CameraManager = .init()
     
     private override init() { }
@@ -26,6 +28,7 @@ final class CameraManager: NSObject, ObservableObject {
 
 // MARK: - Camera
 extension CameraManager: Camera {
+    /// Configures the capture session with a back wide-angle camera and photo output.
     func configureSession() async throws {
         try await withCheckedThrowingContinuation { continuation in
             sessionQueue.async {
@@ -69,6 +72,7 @@ extension CameraManager: Camera {
         }
     }
     
+    /// Starts the capture session after verifying authorization.
     func startSession() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             sessionQueue.async {
@@ -96,6 +100,7 @@ extension CameraManager: Camera {
         }
     }
     
+    /// Stops the capture session if running.
     func stopSession() {
         sessionQueue.async {
             if self.session.isRunning {
@@ -104,6 +109,7 @@ extension CameraManager: Camera {
         }
     }
     
+    /// Captures a single still image from the active session.
     func capturePhoto() async throws -> UIImage {
         try await withCheckedThrowingContinuation { continuation in
             let settings = AVCapturePhotoSettings()
@@ -135,6 +141,7 @@ extension CameraManager: AVCapturePhotoCaptureDelegate {
 
 // MARK: Authorization
 extension CameraManager {
+    /// Reads the current camera authorization status.
     func checkAuthorization() -> AuthorizationStatus {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .notDetermined: return .notDetermined
@@ -146,6 +153,7 @@ extension CameraManager {
     }
     
     @MainActor
+    /// Prompts the user for camera access permission.
     func requestCameraAccess() async -> Bool {
         await AVCaptureDevice.requestAccess(for: .video)
     }
@@ -153,6 +161,7 @@ extension CameraManager {
 
 // MARK: - Error Types
 extension CameraManager {
+    /// Errors that can occur while configuring or capturing from the camera.
     enum CameraError: LocalizedError {
         case unauthorized
         case noDevice
@@ -174,6 +183,7 @@ extension CameraManager {
     }
 }
 
+/// Requirements for any camera manager implementation.
 protocol Camera {
     var session: AVCaptureSession { get }
     func configureSession() async throws

--- a/Resonans/OSFeatures/Camera/CameraPreview.swift
+++ b/Resonans/OSFeatures/Camera/CameraPreview.swift
@@ -8,8 +8,11 @@
 import AVFoundation
 import SwiftUI
 
+/// Wraps an `AVCaptureSession` for display inside SwiftUI views.
 public struct CameraPreview: UIViewRepresentable {
+    /// Capture session providing the video feed.
     let session: AVCaptureSession
+    /// Controls how the video is scaled within the preview layer.
     let videoGravity: AVLayerVideoGravity
     
     public init(
@@ -30,6 +33,7 @@ public struct CameraPreview: UIViewRepresentable {
     public func updateUIView(_ uiView: UIView, context: Context) { }
 }
 
+/// UIView subclass that exposes its backing `AVCaptureVideoPreviewLayer`.
 private class CameraContainer: UIView {
     public override class var layerClass: AnyClass {
         AVCaptureVideoPreviewLayer.self

--- a/Resonans/PhotoLibraryPicker.swift
+++ b/Resonans/PhotoLibraryPicker.swift
@@ -2,7 +2,9 @@ import SwiftUI
 import PhotosUI
 import UniformTypeIdentifiers
 
+/// Presents a `PHPickerViewController` to select photos and videos.
 struct PhotoLibraryPicker: UIViewControllerRepresentable {
+    /// Configuration describing selection limits, filters, and completion handler.
     let config: Config
     func makeCoordinator() -> Coordinator {
         Coordinator(config: config)
@@ -84,6 +86,7 @@ extension PhotoLibraryPicker {
         }
         
         // MARK: - Helpers
+        /// Copies the selected file to a temporary URL so it remains accessible.
         private func copyToTemporary(url: URL) -> URL? {
             let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
             try? FileManager.default.removeItem(at: tempURL)
@@ -96,6 +99,7 @@ extension PhotoLibraryPicker {
             }
         }
         
+        /// Saves a `UIImage` as PNG into a temporary file and returns its URL.
         private func saveImageToTemporaryFile(_ image: UIImage) -> URL? {
             guard let data = image.pngData() else { return nil }
             let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".png")

--- a/Resonans/Utilities/AnimatedMeshGradient.swift
+++ b/Resonans/Utilities/AnimatedMeshGradient.swift
@@ -7,6 +7,7 @@ import CoreGraphics
 //  Created by Lian on 07.11.25.
 //
 
+/// Animated mesh gradient used for decorative backgrounds.
 struct AnimatedMeshGradient: View {
     // Tunable parameters
     private let period: TimeInterval = 12 // slower, smoother loop

--- a/Resonans/Utilities/Color+Ext.swift
+++ b/Resonans/Utilities/Color+Ext.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 extension Color {
+    /// Initializes a `Color` from a six-character hex string (e.g., `#FF00AA`).
     init?(hex: String) {
         var hexString = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
         guard hexString.count == 6,

--- a/Resonans/Utilities/ShimmerEffect.swift
+++ b/Resonans/Utilities/ShimmerEffect.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 // Shimmer Effect Custom View Modifier
 extension View {
+    /// Applies a configurable shimmer overlay to any view.
     @ViewBuilder
     func shimmer(_ config: ShimmerConfig) -> some View {
         self.modifier(ShimmerEffectHelper(config: config))
@@ -84,6 +85,7 @@ fileprivate struct ShimmerEffectHelper: ViewModifier {
 }
 
 // Shimmer Config
+/// Configuration for the shimmer overlay effect.
 struct ShimmerConfig {
     var tint: Color
     var highlight: Color

--- a/Resonans/Utilities/SwipeDismiss.swift
+++ b/Resonans/Utilities/SwipeDismiss.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// Adds a downward drag gesture to dismiss a presented view.
 struct SwipeToDismiss: ViewModifier {
     @Binding var isPresented: Bool
     @State var verticalDragAmount = 0.0

--- a/Resonans/Views/ContentView/ContentView.swift
+++ b/Resonans/Views/ContentView/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Root tab container coordinating the app’s main flows.
 struct ContentView: View {
     @EnvironmentObject private var viewModel: ContentViewModel
     

--- a/Resonans/Views/ContentView/ContentViewModel.swift
+++ b/Resonans/Views/ContentView/ContentViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 
 @MainActor
+/// Shared view model powering the root tab view and onboarding state.
 final class ContentViewModel: ObservableObject {
     @Published var showOnboarding: Bool = false
     
@@ -20,6 +21,7 @@ final class ContentViewModel: ObservableObject {
     
     @Published var favoriteToolIds: Set<ToolIdentifier> = []
     
+    /// Reads persisted favorite flags from `UserDefaults` and rebuilds the set.
     func loadFavoritesOnLaunch() {
         let allTools = toolManager.tools
         for tool in allTools {
@@ -37,6 +39,7 @@ final class ContentViewModel: ObservableObject {
     }
 }
 
+/// Tabs available in the main app container.
 enum TabSelection: Hashable {
     case home
     case tools

--- a/Resonans/Views/HomeDashboardView.swift
+++ b/Resonans/Views/HomeDashboardView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Home screen highlighting onboarding actions, favorites, and recent tools.
 struct HomeDashboardView: View {
 
     let accent: AccentColorOption

--- a/Resonans/Views/OnboardingView.swift
+++ b/Resonans/Views/OnboardingView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Multi-step onboarding flow that captures favorites, workflows, and tips preference.
 struct OnboardingFlowView: View {
     enum WorkflowOption: String, CaseIterable, Identifiable {
         case contentCreator = "Content creator"

--- a/Resonans/Views/SettingsView.swift
+++ b/Resonans/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Settings screen for appearance, feedback toggles, and app information.
 struct SettingsView: View {
     @EnvironmentObject private var viewModel: ContentViewModel
     @AppStorage(AppStorageKey.Settings.appearance) private var appearanceRaw = Appearance.system.rawValue

--- a/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
+++ b/Resonans/Views/Tools/Tool Overview/ToolOverview.swift
@@ -3,6 +3,7 @@
 //  Resonans
 import SwiftUI
 
+/// Card-style representation of a tool with favorite toggles and navigation.
 struct ToolOverview: View {
     private let tool: ToolItem
     init(tool:  ToolItem, presentedInHomeboard atHome: Bool = false){

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionViewModel.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/AudioConversionViewModel.swift
@@ -9,6 +9,7 @@ import AVFoundation
 import Foundation
 import Combine
 
+/// Handles metadata extraction and audio export options for video-to-audio conversions.
 final class AudioConversionViewModel: ObservableObject {
     @Published var selectedFormat: AudioFormat = .mp3
     @Published var bitrate: Double = 192

--- a/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/VideoToAudioConverter.swift
+++ b/Resonans/Views/Tools/ToolItems/AudioExtractor/AudioConversion/VideoToAudioConverter.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Foundation
 import LAME
 
+/// Supported output formats for audio extraction.
 enum AudioFormat: String, CaseIterable {
     case m4a = "M4A"
     case wav = "WAV"
@@ -16,6 +17,7 @@ enum AudioFormat: String, CaseIterable {
     }
 }
 
+/// Converts video files to various audio formats while reporting progress.
 final class VideoToAudioConverter {
     private final class MediaExportContext: @unchecked Sendable {
         let reader: AVAssetReader

--- a/Resonans/Views/ToolsView.swift
+++ b/Resonans/Views/ToolsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// Lists all available tools with favorites prioritized and search support.
 struct ToolsView: View {
     let accent: AccentColorOption
     let primary: Color


### PR DESCRIPTION
## Summary
- add Xcode-style doc comments across models, data sources, and utilities
- document views and tool workflows for onboarding, settings, and conversions
- clarify camera, picker, and conversion helpers with inline explanations

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2a1ec7548320bb6e8f12b52cdf84)